### PR TITLE
CI: remove deprecated `pull_strategy`

### DIFF
--- a/.github/workflows/gnu-data.yml
+++ b/.github/workflows/gnu-data.yml
@@ -128,7 +128,6 @@ jobs:
       with:
         default_author: github_actions
         message: "Update of the data"
-        pull_strategy: 'NO-PULL'
 
     - name: Generate the graphs
       shell: bash


### PR DESCRIPTION
The `pull_strategy` is deprecated and replaced by `pull`. See https://github.com/EndBug/add-and-commit/pull/294

By default, the `EndBug/add-and-commit` action does not pull. See https://github.com/EndBug/add-and-commit/blob/main/action.yml#L47