### PR TITLE
Updated CI to save SVG graphs

### DIFF
--- a/.github/workflows/gnu-data.yml
+++ b/.github/workflows/gnu-data.yml
@@ -143,21 +143,21 @@ jobs:
       with:
         default_author: github_actions
         message: "Refresh the GNU graph"
-        add: gnu-results.png
+        add: gnu-results.svg
 
     - name: Add & Commit the busybox graph
       uses: EndBug/add-and-commit@v9.1.4
       with:
         default_author: github_actions
         message: "Refresh the busybox graph"
-        add: busybox-results.png
+        add: busybox-results.svg
 
     - name: Add & Commit the toybox graph
       uses: EndBug/add-and-commit@v9.1.4
       with:
         default_author: github_actions
         message: "Refresh the toybox graph"
-        add: toybox-results.png
+        add: toybox-results.svg
 
     - name: Add & Commit the individual size graph
       uses: EndBug/add-and-commit@v9.1.4
@@ -171,4 +171,4 @@ jobs:
       with:
         default_author: github_actions
         message: "Refresh the size graph"
-        add: size-results.png
+        add: size-results.svg

--- a/individual-size-graph.py
+++ b/individual-size-graph.py
@@ -11,15 +11,14 @@ import pandas as pd
 
 df = pd.read_json(sys.argv[1], orient="index")
 
+df.index = pd.to_datetime(df.index, utc=True)
+
 Path("individual-size-results").mkdir(exist_ok=True)
 
 
-for name in df.sizes.values[0]:
-    # Check if the name exists in each dictionary
-    sizes = df.sizes.map(lambda v: v.get(name))
-
+for name, series in df["sizes"].apply(pd.Series).items():
     # Filter out None values which indicate missing data for 'name'
-    sizes = sizes[sizes.notnull()]
+    sizes = series.dropna()
 
     if not sizes.empty:
         print(name)
@@ -30,6 +29,6 @@ for name in df.sizes.values[0]:
         fig.autofmt_xdate()
         plt.margins(0.01)
         plt.savefig(f"individual-size-results/{name}.svg", format="svg", dpi=199, bbox_inches="tight")
-        plt.clf()
+        plt.close(fig)
     else:
         print(f"Warning: No data found for '{name}'")


### PR DESCRIPTION
* Updated CI to save the SVG graphs. Fixup after #24
* Further simplified the individual size Python script
  * Fixed bug preventing it from creating graphs for `chcon` and `runcon`

Also see for findutils: https://github.com/uutils/findutils-tracking/pull/8