### PR TITLE
Track commits and contributors for GNU and uutils coreutils

### DIFF
--- a/.github/workflows/gnu-data.yml
+++ b/.github/workflows/gnu-data.yml
@@ -46,6 +46,22 @@ jobs:
         path: uutils-coreutils
         fetch-depth: 1
 
+    - name: Checkout uutils/coreutils history for the activity graph
+      uses: actions/checkout@v7
+      with:
+        repository: uutils/coreutils
+        path: uutils-coreutils-history
+        fetch-depth: 0
+        filter: blob:none
+
+    - name: Checkout coreutils/coreutils history for the activity graph
+      uses: actions/checkout@v7
+      with:
+        repository: coreutils/coreutils
+        path: gnu-coreutils-history
+        fetch-depth: 0
+        filter: blob:none
+
     - name: Download the GNU result
       uses: dawidd6/action-download-artifact@v21
       with:
@@ -157,6 +173,13 @@ jobs:
        mv merged.json unsafe-result.json
        rm -f unsafe-latest.json
 
+    - name: Regenerate the commit/contributor activity data
+      shell: bash
+      run: |
+       # Fully derived from the two git histories, so no merge needed.
+       python3 activity_count.py gnu-coreutils-history uutils-coreutils-history > activity-result.json
+       tail -30 activity-result.json
+
     - name: Add & Commit
       if: github.event_name != 'pull_request'
       uses: EndBug/add-and-commit@v10.0.0
@@ -174,6 +197,7 @@ jobs:
         python individual-size-graph.py individual-size-result.json
         python size-graph.py size-result.json
         python unsafe-graph.py unsafe-result.json
+        python activity-graph.py activity-result.json
 
     - name: Add & Commit the GNU graph
       if: github.event_name != 'pull_request'
@@ -227,4 +251,13 @@ jobs:
         default_author: github_actions
         message: "Refresh the unsafe graph"
         add: unsafe-results.svg
+        pull: '--rebase --autostash'
+
+    - name: Add & Commit the activity graph
+      if: github.event_name != 'pull_request'
+      uses: EndBug/add-and-commit@v10.0.0
+      with:
+        default_author: github_actions
+        message: "Refresh the activity graph"
+        add: activity-results.svg
         pull: '--rebase --autostash'

--- a/README.md
+++ b/README.md
@@ -51,3 +51,16 @@ Tracks how much `unsafe` Rust the project relies on. The total counts
 
 Data lives in [unsafe-result.json](unsafe-result.json). Counting logic is in
 `unsafe_count.py`
+
+## Development activity
+
+Monthly commits and contributors for both GNU coreutils and uutils coreutils
+since 2021. Non-merge commits only, authors deduplicated via `.mailmap` and
+bots (dependabot, renovate, github-actions, …) excluded. The cumulative
+contributor panel counts every contributor since each project's first commit,
+not just those active since 2021.
+
+![Activity evolution](activity-results.svg)
+
+Regenerated from both git histories once a day by github actions
+([activity-result.json](activity-result.json)).

--- a/activity-graph.py
+++ b/activity-graph.py
@@ -1,0 +1,142 @@
+# This file is part of the uutils coreutils package.
+#
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+
+"""Render activity-result.json with three stacked panels comparing GNU and
+uutils coreutils: commits per month, active contributors per month and
+cumulative distinct contributors. All panels share an x-axis so trends line
+up vertically.
+"""
+
+import sys
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+from graph_common import (
+    add_gnu_release_markers,
+    apply_smoothing,
+    setup_theme,
+    style_axes,
+    style_legend,
+)
+
+if len(sys.argv) <= 1:
+    print("activity-graph.py: <json file>")
+    sys.exit()
+
+raw = pd.read_json(sys.argv[1], orient="index", convert_dates=False)
+
+# Flatten {"2021-01": {"gnu": {...}, "uutils": {...}}} into one row per
+# (month, project).
+rows = []
+for month, projects in raw.iterrows():
+    for project, values in projects.items():
+        rows.append(
+            {
+                "date": pd.to_datetime(month, format="%Y-%m", utc=True),
+                "project": project,
+                **{k: int(v) for k, v in values.items()},
+            }
+        )
+
+df = pd.DataFrame(rows).sort_values("date")
+
+print(df)
+
+setup_theme()
+
+palette = {
+    "gnu": "#0066CC",
+    "uutils": "#10B981",
+}
+
+label_map = {
+    "gnu": "GNU coreutils",
+    "uutils": "uutils coreutils",
+}
+
+
+def plot_panel(ax, metric, ylabel, smooth=True):
+    """Plot one metric for both projects on `ax`."""
+    data = df[["date", "project", metric]].copy()
+    if smooth:
+        # 3-month rolling mean: monthly counts are spiky (release crunches,
+        # hackathons) and the trend is what matters here.
+        data["value"] = apply_smoothing(data, "project", metric, window=3)
+    else:
+        data["value"] = data[metric]
+
+    sns.lineplot(
+        data=data,
+        x="date",
+        y="value",
+        hue="project",
+        palette=palette,
+        hue_order=["gnu", "uutils"],
+        linewidth=3,
+        ax=ax,
+        markers=False,
+        dashes=False,
+        alpha=1,
+        zorder=3,
+    )
+    style_axes(ax, xlabel="Date", ylabel=ylabel)
+
+    y_max = data["value"].max()
+    add_gnu_release_markers(ax, df["date"].min(), df["date"].max(), y_max)
+
+    handles, labels = ax.get_legend_handles_labels()
+    labels = [label_map.get(label, label) for label in labels]
+    style_legend(ax, handles, labels, ncol=2, loc="upper left")
+
+
+fig, (ax_top, ax_mid, ax_bot) = plt.subplots(
+    3, 1, figsize=(18, 20), dpi=100, sharex=True
+)
+
+plot_panel(ax_top, "commits", "Commits / month")
+plot_panel(ax_mid, "authors", "Active contributors / month")
+plot_panel(ax_bot, "cumulative_authors", "Distinct contributors (since day 1)", False)
+
+fig.suptitle(
+    "GNU vs uutils coreutils — Development Activity Since 2021",
+    fontsize=26,
+    fontweight="bold",
+    color="#1a1a1a",
+    y=0.995,
+)
+fig.text(
+    0.5,
+    0.972,
+    "Non-merge commits, bots excluded. Top two panels are 3-month rolling averages; "
+    "the cumulative panel counts every contributor since each project's first commit.",
+    ha="center",
+    va="top",
+    fontsize=13,
+    color="#6B7280",
+    style="italic",
+    alpha=0.9,
+)
+
+# Hide the upper panels' x-tick labels — they duplicate the bottom panel's.
+for ax in (ax_top, ax_mid):
+    plt.setp(ax.get_xticklabels(), visible=False)
+    ax.set_xlabel("")
+
+plt.tight_layout(rect=[0, 0, 1, 0.96])
+
+plt.savefig(
+    "activity-results.svg",
+    format="svg",
+    dpi=300,
+    bbox_inches="tight",
+    facecolor="white",
+    edgecolor="none",
+    metadata={
+        "Creator": "uutils coreutils tracking",
+        "Title": "Development Activity Evolution",
+    },
+)

--- a/activity-result.json
+++ b/activity-result.json
@@ -1,0 +1,806 @@
+{
+  "2021-01": {
+    "gnu": {
+      "commits": "8",
+      "authors": "3",
+      "cumulative_authors": "242"
+    },
+    "uutils": {
+      "commits": "30",
+      "authors": "6",
+      "cumulative_authors": "219"
+    }
+  },
+  "2021-02": {
+    "gnu": {
+      "commits": "6",
+      "authors": "4",
+      "cumulative_authors": "242"
+    },
+    "uutils": {
+      "commits": "57",
+      "authors": "7",
+      "cumulative_authors": "220"
+    }
+  },
+  "2021-03": {
+    "gnu": {
+      "commits": "23",
+      "authors": "5",
+      "cumulative_authors": "243"
+    },
+    "uutils": {
+      "commits": "208",
+      "authors": "55",
+      "cumulative_authors": "267"
+    }
+  },
+  "2021-04": {
+    "gnu": {
+      "commits": "9",
+      "authors": "4",
+      "cumulative_authors": "244"
+    },
+    "uutils": {
+      "commits": "288",
+      "authors": "42",
+      "cumulative_authors": "289"
+    }
+  },
+  "2021-05": {
+    "gnu": {
+      "commits": "16",
+      "authors": "4",
+      "cumulative_authors": "244"
+    },
+    "uutils": {
+      "commits": "323",
+      "authors": "31",
+      "cumulative_authors": "300"
+    }
+  },
+  "2021-06": {
+    "gnu": {
+      "commits": "9",
+      "authors": "4",
+      "cumulative_authors": "245"
+    },
+    "uutils": {
+      "commits": "364",
+      "authors": "25",
+      "cumulative_authors": "311"
+    }
+  },
+  "2021-07": {
+    "gnu": {
+      "commits": "20",
+      "authors": "3",
+      "cumulative_authors": "246"
+    },
+    "uutils": {
+      "commits": "193",
+      "authors": "24",
+      "cumulative_authors": "318"
+    }
+  },
+  "2021-08": {
+    "gnu": {
+      "commits": "19",
+      "authors": "4",
+      "cumulative_authors": "246"
+    },
+    "uutils": {
+      "commits": "194",
+      "authors": "22",
+      "cumulative_authors": "325"
+    }
+  },
+  "2021-09": {
+    "gnu": {
+      "commits": "54",
+      "authors": "5",
+      "cumulative_authors": "248"
+    },
+    "uutils": {
+      "commits": "101",
+      "authors": "14",
+      "cumulative_authors": "328"
+    }
+  },
+  "2021-10": {
+    "gnu": {
+      "commits": "12",
+      "authors": "2",
+      "cumulative_authors": "248"
+    },
+    "uutils": {
+      "commits": "81",
+      "authors": "11",
+      "cumulative_authors": "330"
+    }
+  },
+  "2021-11": {
+    "gnu": {
+      "commits": "20",
+      "authors": "2",
+      "cumulative_authors": "248"
+    },
+    "uutils": {
+      "commits": "58",
+      "authors": "11",
+      "cumulative_authors": "331"
+    }
+  },
+  "2021-12": {
+    "gnu": {
+      "commits": "24",
+      "authors": "5",
+      "cumulative_authors": "249"
+    },
+    "uutils": {
+      "commits": "71",
+      "authors": "10",
+      "cumulative_authors": "336"
+    }
+  },
+  "2022-01": {
+    "gnu": {
+      "commits": "77",
+      "authors": "4",
+      "cumulative_authors": "251"
+    },
+    "uutils": {
+      "commits": "317",
+      "authors": "20",
+      "cumulative_authors": "347"
+    }
+  },
+  "2022-02": {
+    "gnu": {
+      "commits": "37",
+      "authors": "3",
+      "cumulative_authors": "251"
+    },
+    "uutils": {
+      "commits": "225",
+      "authors": "42",
+      "cumulative_authors": "377"
+    }
+  },
+  "2022-03": {
+    "gnu": {
+      "commits": "12",
+      "authors": "4",
+      "cumulative_authors": "253"
+    },
+    "uutils": {
+      "commits": "141",
+      "authors": "27",
+      "cumulative_authors": "384"
+    }
+  },
+  "2022-04": {
+    "gnu": {
+      "commits": "35",
+      "authors": "4",
+      "cumulative_authors": "253"
+    },
+    "uutils": {
+      "commits": "120",
+      "authors": "15",
+      "cumulative_authors": "390"
+    }
+  },
+  "2022-05": {
+    "gnu": {
+      "commits": "14",
+      "authors": "3",
+      "cumulative_authors": "253"
+    },
+    "uutils": {
+      "commits": "104",
+      "authors": "13",
+      "cumulative_authors": "392"
+    }
+  },
+  "2022-06": {
+    "gnu": {
+      "commits": "9",
+      "authors": "3",
+      "cumulative_authors": "253"
+    },
+    "uutils": {
+      "commits": "99",
+      "authors": "17",
+      "cumulative_authors": "402"
+    }
+  },
+  "2022-07": {
+    "gnu": {
+      "commits": "13",
+      "authors": "4",
+      "cumulative_authors": "255"
+    },
+    "uutils": {
+      "commits": "63",
+      "authors": "15",
+      "cumulative_authors": "407"
+    }
+  },
+  "2022-08": {
+    "gnu": {
+      "commits": "15",
+      "authors": "1",
+      "cumulative_authors": "255"
+    },
+    "uutils": {
+      "commits": "135",
+      "authors": "16",
+      "cumulative_authors": "413"
+    }
+  },
+  "2022-09": {
+    "gnu": {
+      "commits": "28",
+      "authors": "4",
+      "cumulative_authors": "257"
+    },
+    "uutils": {
+      "commits": "161",
+      "authors": "12",
+      "cumulative_authors": "417"
+    }
+  },
+  "2022-10": {
+    "gnu": {
+      "commits": "4",
+      "authors": "1",
+      "cumulative_authors": "257"
+    },
+    "uutils": {
+      "commits": "152",
+      "authors": "15",
+      "cumulative_authors": "420"
+    }
+  },
+  "2022-11": {
+    "gnu": {
+      "commits": "10",
+      "authors": "3",
+      "cumulative_authors": "258"
+    },
+    "uutils": {
+      "commits": "95",
+      "authors": "13",
+      "cumulative_authors": "423"
+    }
+  },
+  "2022-12": {
+    "gnu": {
+      "commits": "13",
+      "authors": "4",
+      "cumulative_authors": "259"
+    },
+    "uutils": {
+      "commits": "68",
+      "authors": "11",
+      "cumulative_authors": "427"
+    }
+  },
+  "2023-01": {
+    "gnu": {
+      "commits": "28",
+      "authors": "4",
+      "cumulative_authors": "259"
+    },
+    "uutils": {
+      "commits": "65",
+      "authors": "11",
+      "cumulative_authors": "428"
+    }
+  },
+  "2023-02": {
+    "gnu": {
+      "commits": "30",
+      "authors": "4",
+      "cumulative_authors": "260"
+    },
+    "uutils": {
+      "commits": "121",
+      "authors": "29",
+      "cumulative_authors": "447"
+    }
+  },
+  "2023-03": {
+    "gnu": {
+      "commits": "50",
+      "authors": "5",
+      "cumulative_authors": "260"
+    },
+    "uutils": {
+      "commits": "242",
+      "authors": "39",
+      "cumulative_authors": "471"
+    }
+  },
+  "2023-04": {
+    "gnu": {
+      "commits": "33",
+      "authors": "4",
+      "cumulative_authors": "261"
+    },
+    "uutils": {
+      "commits": "160",
+      "authors": "21",
+      "cumulative_authors": "484"
+    }
+  },
+  "2023-05": {
+    "gnu": {
+      "commits": "21",
+      "authors": "3",
+      "cumulative_authors": "261"
+    },
+    "uutils": {
+      "commits": "152",
+      "authors": "21",
+      "cumulative_authors": "490"
+    }
+  },
+  "2023-06": {
+    "gnu": {
+      "commits": "24",
+      "authors": "5",
+      "cumulative_authors": "262"
+    },
+    "uutils": {
+      "commits": "92",
+      "authors": "20",
+      "cumulative_authors": "503"
+    }
+  },
+  "2023-07": {
+    "gnu": {
+      "commits": "39",
+      "authors": "5",
+      "cumulative_authors": "262"
+    },
+    "uutils": {
+      "commits": "76",
+      "authors": "16",
+      "cumulative_authors": "506"
+    }
+  },
+  "2023-08": {
+    "gnu": {
+      "commits": "69",
+      "authors": "5",
+      "cumulative_authors": "263"
+    },
+    "uutils": {
+      "commits": "105",
+      "authors": "14",
+      "cumulative_authors": "513"
+    }
+  },
+  "2023-09": {
+    "gnu": {
+      "commits": "42",
+      "authors": "4",
+      "cumulative_authors": "264"
+    },
+    "uutils": {
+      "commits": "94",
+      "authors": "15",
+      "cumulative_authors": "518"
+    }
+  },
+  "2023-10": {
+    "gnu": {
+      "commits": "22",
+      "authors": "2",
+      "cumulative_authors": "264"
+    },
+    "uutils": {
+      "commits": "140",
+      "authors": "19",
+      "cumulative_authors": "529"
+    }
+  },
+  "2023-11": {
+    "gnu": {
+      "commits": "13",
+      "authors": "3",
+      "cumulative_authors": "265"
+    },
+    "uutils": {
+      "commits": "124",
+      "authors": "24",
+      "cumulative_authors": "543"
+    }
+  },
+  "2023-12": {
+    "gnu": {
+      "commits": "17",
+      "authors": "3",
+      "cumulative_authors": "266"
+    },
+    "uutils": {
+      "commits": "201",
+      "authors": "20",
+      "cumulative_authors": "555"
+    }
+  },
+  "2024-01": {
+    "gnu": {
+      "commits": "12",
+      "authors": "6",
+      "cumulative_authors": "269"
+    },
+    "uutils": {
+      "commits": "134",
+      "authors": "25",
+      "cumulative_authors": "570"
+    }
+  },
+  "2024-02": {
+    "gnu": {
+      "commits": "29",
+      "authors": "9",
+      "cumulative_authors": "275"
+    },
+    "uutils": {
+      "commits": "101",
+      "authors": "18",
+      "cumulative_authors": "576"
+    }
+  },
+  "2024-03": {
+    "gnu": {
+      "commits": "41",
+      "authors": "8",
+      "cumulative_authors": "276"
+    },
+    "uutils": {
+      "commits": "157",
+      "authors": "22",
+      "cumulative_authors": "588"
+    }
+  },
+  "2024-04": {
+    "gnu": {
+      "commits": "14",
+      "authors": "3",
+      "cumulative_authors": "276"
+    },
+    "uutils": {
+      "commits": "115",
+      "authors": "22",
+      "cumulative_authors": "599"
+    }
+  },
+  "2024-05": {
+    "gnu": {
+      "commits": "26",
+      "authors": "7",
+      "cumulative_authors": "278"
+    },
+    "uutils": {
+      "commits": "90",
+      "authors": "18",
+      "cumulative_authors": "606"
+    }
+  },
+  "2024-06": {
+    "gnu": {
+      "commits": "6",
+      "authors": "4",
+      "cumulative_authors": "278"
+    },
+    "uutils": {
+      "commits": "56",
+      "authors": "13",
+      "cumulative_authors": "611"
+    }
+  },
+  "2024-07": {
+    "gnu": {
+      "commits": "12",
+      "authors": "5",
+      "cumulative_authors": "278"
+    },
+    "uutils": {
+      "commits": "76",
+      "authors": "17",
+      "cumulative_authors": "618"
+    }
+  },
+  "2024-08": {
+    "gnu": {
+      "commits": "33",
+      "authors": "4",
+      "cumulative_authors": "279"
+    },
+    "uutils": {
+      "commits": "24",
+      "authors": "6",
+      "cumulative_authors": "619"
+    }
+  },
+  "2024-09": {
+    "gnu": {
+      "commits": "29",
+      "authors": "4",
+      "cumulative_authors": "279"
+    },
+    "uutils": {
+      "commits": "61",
+      "authors": "15",
+      "cumulative_authors": "626"
+    }
+  },
+  "2024-10": {
+    "gnu": {
+      "commits": "22",
+      "authors": "8",
+      "cumulative_authors": "281"
+    },
+    "uutils": {
+      "commits": "69",
+      "authors": "20",
+      "cumulative_authors": "634"
+    }
+  },
+  "2024-11": {
+    "gnu": {
+      "commits": "69",
+      "authors": "5",
+      "cumulative_authors": "282"
+    },
+    "uutils": {
+      "commits": "53",
+      "authors": "9",
+      "cumulative_authors": "636"
+    }
+  },
+  "2024-12": {
+    "gnu": {
+      "commits": "14",
+      "authors": "4",
+      "cumulative_authors": "283"
+    },
+    "uutils": {
+      "commits": "121",
+      "authors": "21",
+      "cumulative_authors": "647"
+    }
+  },
+  "2025-01": {
+    "gnu": {
+      "commits": "46",
+      "authors": "6",
+      "cumulative_authors": "284"
+    },
+    "uutils": {
+      "commits": "197",
+      "authors": "22",
+      "cumulative_authors": "656"
+    }
+  },
+  "2025-02": {
+    "gnu": {
+      "commits": "24",
+      "authors": "5",
+      "cumulative_authors": "284"
+    },
+    "uutils": {
+      "commits": "76",
+      "authors": "18",
+      "cumulative_authors": "664"
+    }
+  },
+  "2025-03": {
+    "gnu": {
+      "commits": "11",
+      "authors": "3",
+      "cumulative_authors": "285"
+    },
+    "uutils": {
+      "commits": "237",
+      "authors": "33",
+      "cumulative_authors": "683"
+    }
+  },
+  "2025-04": {
+    "gnu": {
+      "commits": "23",
+      "authors": "5",
+      "cumulative_authors": "285"
+    },
+    "uutils": {
+      "commits": "212",
+      "authors": "33",
+      "cumulative_authors": "702"
+    }
+  },
+  "2025-05": {
+    "gnu": {
+      "commits": "44",
+      "authors": "3",
+      "cumulative_authors": "285"
+    },
+    "uutils": {
+      "commits": "184",
+      "authors": "30",
+      "cumulative_authors": "713"
+    }
+  },
+  "2025-06": {
+    "gnu": {
+      "commits": "82",
+      "authors": "5",
+      "cumulative_authors": "286"
+    },
+    "uutils": {
+      "commits": "249",
+      "authors": "28",
+      "cumulative_authors": "728"
+    }
+  },
+  "2025-07": {
+    "gnu": {
+      "commits": "84",
+      "authors": "7",
+      "cumulative_authors": "288"
+    },
+    "uutils": {
+      "commits": "157",
+      "authors": "19",
+      "cumulative_authors": "736"
+    }
+  },
+  "2025-08": {
+    "gnu": {
+      "commits": "60",
+      "authors": "5",
+      "cumulative_authors": "288"
+    },
+    "uutils": {
+      "commits": "168",
+      "authors": "10",
+      "cumulative_authors": "739"
+    }
+  },
+  "2025-09": {
+    "gnu": {
+      "commits": "91",
+      "authors": "8",
+      "cumulative_authors": "290"
+    },
+    "uutils": {
+      "commits": "160",
+      "authors": "30",
+      "cumulative_authors": "761"
+    }
+  },
+  "2025-10": {
+    "gnu": {
+      "commits": "59",
+      "authors": "6",
+      "cumulative_authors": "290"
+    },
+    "uutils": {
+      "commits": "174",
+      "authors": "26",
+      "cumulative_authors": "774"
+    }
+  },
+  "2025-11": {
+    "gnu": {
+      "commits": "92",
+      "authors": "6",
+      "cumulative_authors": "290"
+    },
+    "uutils": {
+      "commits": "205",
+      "authors": "27",
+      "cumulative_authors": "783"
+    }
+  },
+  "2025-12": {
+    "gnu": {
+      "commits": "82",
+      "authors": "5",
+      "cumulative_authors": "291"
+    },
+    "uutils": {
+      "commits": "190",
+      "authors": "37",
+      "cumulative_authors": "797"
+    }
+  },
+  "2026-01": {
+    "gnu": {
+      "commits": "142",
+      "authors": "10",
+      "cumulative_authors": "294"
+    },
+    "uutils": {
+      "commits": "372",
+      "authors": "63",
+      "cumulative_authors": "832"
+    }
+  },
+  "2026-02": {
+    "gnu": {
+      "commits": "107",
+      "authors": "8",
+      "cumulative_authors": "297"
+    },
+    "uutils": {
+      "commits": "263",
+      "authors": "54",
+      "cumulative_authors": "861"
+    }
+  },
+  "2026-03": {
+    "gnu": {
+      "commits": "126",
+      "authors": "9",
+      "cumulative_authors": "299"
+    },
+    "uutils": {
+      "commits": "262",
+      "authors": "35",
+      "cumulative_authors": "877"
+    }
+  },
+  "2026-04": {
+    "gnu": {
+      "commits": "95",
+      "authors": "8",
+      "cumulative_authors": "300"
+    },
+    "uutils": {
+      "commits": "321",
+      "authors": "37",
+      "cumulative_authors": "896"
+    }
+  },
+  "2026-05": {
+    "gnu": {
+      "commits": "46",
+      "authors": "5",
+      "cumulative_authors": "300"
+    },
+    "uutils": {
+      "commits": "207",
+      "authors": "35",
+      "cumulative_authors": "912"
+    }
+  },
+  "2026-06": {
+    "gnu": {
+      "commits": "13",
+      "authors": "3",
+      "cumulative_authors": "300"
+    },
+    "uutils": {
+      "commits": "241",
+      "authors": "32",
+      "cumulative_authors": "931"
+    }
+  },
+  "2026-07": {
+    "gnu": {
+      "commits": "0",
+      "authors": "0",
+      "cumulative_authors": "300"
+    },
+    "uutils": {
+      "commits": "295",
+      "authors": "58",
+      "cumulative_authors": "966"
+    }
+  }
+}

--- a/activity-results.svg
+++ b/activity-results.svg
@@ -1,0 +1,5653 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1271.626875pt" height="1427.286094pt" viewBox="0 0 1271.626875 1427.286094" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <title>Development Activity Evolution</title>
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>Development Activity Evolution</dc:title>
+    <dc:date>2026-08-02T23:15:32.860419</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>uutils coreutils tracking</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 1427.286094 
+L 1271.626875 1427.286094 
+L 1271.626875 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 99.326875 507.713333 
+L 1264.426875 507.713333 
+L 1264.426875 127.504706 
+L 99.326875 127.504706 
+z
+" style="fill: #fafafa; opacity: 0.6"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 99.326875 507.713333 
+L 1264.426875 507.713333 
+L 1264.426875 127.504706 
+L 99.326875 127.504706 
+L 99.326875 507.713333 
+z
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-width: 3; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 110.749424 507.713333 
+L 110.749424 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="me259dc2b60" d="M 0 0 
+L 0 9 
+" style="stroke: #555555; stroke-width: 1.875"/>
+      </defs>
+      <g>
+       <use xlink:href="#me259dc2b60" x="110.749424" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 318.483873 507.713333 
+L 318.483873 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#me259dc2b60" x="318.483873" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 526.218322 507.713333 
+L 526.218322 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#me259dc2b60" x="526.218322" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 733.952771 507.713333 
+L 733.952771 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#me259dc2b60" x="733.952771" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 942.256356 507.713333 
+L 942.256356 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#me259dc2b60" x="942.256356" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 1149.990805 507.713333 
+L 1149.990805 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#me259dc2b60" x="1149.990805" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 162.82532 507.713333 
+L 162.82532 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="m3a3fa2f38c" d="M 0 0 
+L 0 6 
+" style="stroke: #555555; stroke-width: 1.5"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="162.82532" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 214.901216 507.713333 
+L 214.901216 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="214.901216" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 266.977112 507.713333 
+L 266.977112 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="266.977112" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 319.053009 507.713333 
+L 319.053009 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="319.053009" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 371.128905 507.713333 
+L 371.128905 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="371.128905" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 423.204801 507.713333 
+L 423.204801 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="423.204801" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 475.280697 507.713333 
+L 475.280697 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="475.280697" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 527.356593 507.713333 
+L 527.356593 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="527.356593" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 579.432489 507.713333 
+L 579.432489 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="579.432489" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 631.508385 507.713333 
+L 631.508385 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="631.508385" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 683.584281 507.713333 
+L 683.584281 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="683.584281" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 735.660178 507.713333 
+L 735.660178 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="735.660178" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 787.736074 507.713333 
+L 787.736074 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="787.736074" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 839.81197 507.713333 
+L 839.81197 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="839.81197" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 891.887866 507.713333 
+L 891.887866 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="891.887866" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 943.963762 507.713333 
+L 943.963762 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="943.963762" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 996.039658 507.713333 
+L 996.039658 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="996.039658" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 1048.115554 507.713333 
+L 1048.115554 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1048.115554" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 1100.19145 507.713333 
+L 1100.19145 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1100.19145" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 1152.267347 507.713333 
+L 1152.267347 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1152.267347" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 1204.343243 507.713333 
+L 1204.343243 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1204.343243" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 1256.419139 507.713333 
+L 1256.419139 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1256.419139" y="515.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_57">
+      <path d="M 99.326875 507.713333 
+L 1264.426875 507.713333 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_58">
+      <defs>
+       <path id="m07c430eed5" d="M 0 0 
+L -9 0 
+" style="stroke: #555555; stroke-width: 1.875"/>
+      </defs>
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="507.713333" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g style="fill: #555555" transform="translate(68.32875 513.982044) scale(0.165 -0.165)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_59">
+      <path d="M 99.326875 451.952004 
+L 1264.426875 451.952004 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="451.952004" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 50 -->
+      <g style="fill: #555555" transform="translate(57.830625 458.220714) scale(0.165 -0.165)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_61">
+      <path d="M 99.326875 396.190674 
+L 1264.426875 396.190674 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="396.190674" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 100 -->
+      <g style="fill: #555555" transform="translate(47.3325 402.459385) scale(0.165 -0.165)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_63">
+      <path d="M 99.326875 340.429344 
+L 1264.426875 340.429344 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="340.429344" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 150 -->
+      <g style="fill: #555555" transform="translate(47.3325 346.698055) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_65">
+      <path d="M 99.326875 284.668014 
+L 1264.426875 284.668014 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="284.668014" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 200 -->
+      <g style="fill: #555555" transform="translate(47.3325 290.936725) scale(0.165 -0.165)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_67">
+      <path d="M 99.326875 228.906684 
+L 1264.426875 228.906684 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="228.906684" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 250 -->
+      <g style="fill: #555555" transform="translate(47.3325 235.175395) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_69">
+      <path d="M 99.326875 173.145354 
+L 1264.426875 173.145354 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="173.145354" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 300 -->
+      <g style="fill: #555555" transform="translate(47.3325 179.414065) scale(0.165 -0.165)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_71">
+      <path d="M 99.326875 496.561067 
+L 1264.426875 496.561067 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_72">
+      <defs>
+       <path id="m8b351d5d15" d="M 0 0 
+L -6 0 
+" style="stroke: #555555; stroke-width: 1.5"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="496.561067" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_73">
+      <path d="M 99.326875 485.408801 
+L 1264.426875 485.408801 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="485.408801" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_75">
+      <path d="M 99.326875 474.256535 
+L 1264.426875 474.256535 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="474.256535" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_77">
+      <path d="M 99.326875 463.104269 
+L 1264.426875 463.104269 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="463.104269" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_79">
+      <path d="M 99.326875 440.799738 
+L 1264.426875 440.799738 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="440.799738" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_81">
+      <path d="M 99.326875 429.647472 
+L 1264.426875 429.647472 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="429.647472" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_83">
+      <path d="M 99.326875 418.495206 
+L 1264.426875 418.495206 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="418.495206" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_85">
+      <path d="M 99.326875 407.34294 
+L 1264.426875 407.34294 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="407.34294" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_87">
+      <path d="M 99.326875 385.038408 
+L 1264.426875 385.038408 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="385.038408" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_89">
+      <path d="M 99.326875 373.886142 
+L 1264.426875 373.886142 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="373.886142" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_91">
+      <path d="M 99.326875 362.733876 
+L 1264.426875 362.733876 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="362.733876" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_93">
+      <path d="M 99.326875 351.58161 
+L 1264.426875 351.58161 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="351.58161" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_95">
+      <path d="M 99.326875 329.277078 
+L 1264.426875 329.277078 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="329.277078" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_97">
+      <path d="M 99.326875 318.124812 
+L 1264.426875 318.124812 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="318.124812" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_99">
+      <path d="M 99.326875 306.972546 
+L 1264.426875 306.972546 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="306.972546" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_101">
+      <path d="M 99.326875 295.82028 
+L 1264.426875 295.82028 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="295.82028" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_103">
+      <path d="M 99.326875 273.515748 
+L 1264.426875 273.515748 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="273.515748" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_105">
+      <path d="M 99.326875 262.363482 
+L 1264.426875 262.363482 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="262.363482" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_107">
+      <path d="M 99.326875 251.211216 
+L 1264.426875 251.211216 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="251.211216" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_109">
+      <path d="M 99.326875 240.05895 
+L 1264.426875 240.05895 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="240.05895" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_111">
+      <path d="M 99.326875 217.754418 
+L 1264.426875 217.754418 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="217.754418" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_113">
+      <path d="M 99.326875 206.602152 
+L 1264.426875 206.602152 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="206.602152" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_115">
+      <path d="M 99.326875 195.449886 
+L 1264.426875 195.449886 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="195.449886" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_117">
+      <path d="M 99.326875 184.29762 
+L 1264.426875 184.29762 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="184.29762" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_119">
+      <path d="M 99.326875 161.993088 
+L 1264.426875 161.993088 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="161.993088" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_121">
+      <path d="M 99.326875 150.840822 
+L 1264.426875 150.840822 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="150.840822" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_123">
+      <path d="M 99.326875 139.688556 
+L 1264.426875 139.688556 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="139.688556" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_125">
+      <path d="M 99.326875 128.53629 
+L 1264.426875 128.53629 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="128.53629" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- Commits / month -->
+     <g style="fill: #374151" transform="translate(29.212969 389.708629) rotate(-90) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-Bold-43" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-2f" d="M 1644 4666 
+L 2338 4666 
+L 691 -594 
+L 0 -594 
+L 1644 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Bold-43"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(73.388672 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(142.089844 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(246.289062 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(350.488281 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(384.765625 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-73" transform="translate(432.568359 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(492.089844 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(526.904297 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(563.427734 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(598.242188 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(702.441406 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(771.142578 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(842.333984 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-68" transform="translate(890.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_1"/>
+   <g id="FillBetweenPolyCollection_2"/>
+   <g id="line2d_127">
+    <path d="M 262.139461 507.713333 
+L 262.139461 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_128">
+    <path d="M 377.673963 507.713333 
+L 377.673963 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_129">
+    <path d="M 570.610889 507.713333 
+L 570.610889 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_130">
+    <path d="M 587.115818 507.713333 
+L 587.115818 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_131">
+    <path d="M 662.810837 507.713333 
+L 662.810837 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_132">
+    <path d="M 783.467558 507.713333 
+L 783.467558 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_133">
+    <path d="M 951.362523 507.713333 
+L 951.362523 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_134">
+    <path d="M 998.031632 507.713333 
+L 998.031632 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_135">
+    <path d="M 1092.508122 507.713333 
+L 1092.508122 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_136">
+    <path d="M 1120.39576 507.713333 
+L 1120.39576 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_137">
+    <path d="M 1169.341411 507.713333 
+L 1169.341411 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_138">
+    <path d="M 1213.733978 507.713333 
+L 1213.733978 127.504706 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.326875 507.713333 
+L 91.326875 127.504706 
+" style="fill: none; stroke: #9ca3af; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 99.326875 515.713333 
+L 1264.426875 515.713333 
+" style="fill: none; stroke: #9ca3af; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_139">
+    <path d="M 110.749424 499.906747 
+L 128.392624 493.958872 
+L 144.328417 493.58713 
+L 161.971617 489.869708 
+L 179.045681 495.074099 
+L 196.688881 490.984934 
+L 213.762945 489.869708 
+L 231.406145 473.141309 
+L 249.049345 476.115246 
+L 266.123409 475.743504 
+L 283.766609 486.89577 
+L 300.840673 462.732527 
+L 318.483873 456.41291 
+L 336.127073 460.873816 
+L 352.062866 476.486989 
+L 369.706066 485.037059 
+L 386.78013 486.152286 
+L 404.42333 494.330614 
+L 421.497394 493.958872 
+L 439.140594 486.89577 
+L 456.783794 490.24145 
+L 473.857858 492.100161 
+L 491.501058 497.676294 
+L 508.575122 488.754481 
+L 526.218322 481.319637 
+L 543.861522 467.565176 
+L 559.797315 465.706465 
+L 577.440515 469.052145 
+L 594.514579 478.717442 
+L 612.157779 476.486989 
+L 629.231843 458.643363 
+L 646.875043 451.952004 
+L 664.518243 458.271621 
+L 681.592307 479.089184 
+L 699.235507 488.382739 
+L 716.309571 492.100161 
+L 733.952771 486.152286 
+L 751.595971 477.230473 
+L 768.1009 476.486989 
+L 785.7441 477.602215 
+L 802.818164 490.613192 
+L 820.461364 491.356677 
+L 837.535428 488.754481 
+L 855.178628 480.204411 
+L 872.821827 476.486989 
+L 889.895892 463.104269 
+L 907.539092 468.680402 
+L 924.613156 459.75859 
+L 942.256356 476.486989 
+L 959.899555 477.602215 
+L 975.835349 486.152286 
+L 993.478549 478.717442 
+L 1010.552613 452.323746 
+L 1028.195813 429.647472 
+L 1045.269877 423.699596 
+L 1062.913077 420.353917 
+L 1080.556277 429.647472 
+L 1097.630341 417.751721 
+L 1115.273541 421.097401 
+L 1132.347605 390.242798 
+L 1149.990805 384.666666 
+L 1167.634004 368.310009 
+L 1183.569798 385.781892 
+L 1201.212998 408.458166 
+L 1218.287062 450.465035 
+L 1235.930262 485.780544 
+L 1253.004326 500.46436 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #0066cc; stroke-width: 3; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_140">
+    <path d="M 110.749424 459.200976 
+L 128.392624 398.049385 
+L 144.328417 302.139897 
+L 161.971617 203.256472 
+L 179.045681 145.264689 
+L 196.688881 180.580198 
+L 213.762945 228.534942 
+L 231.406145 326.30314 
+L 249.049345 367.938267 
+L 266.123409 418.495206 
+L 283.766609 429.647472 
+L 300.840673 341.916313 
+L 318.483873 279.835365 
+L 336.127073 253.813412 
+L 352.062866 327.046625 
+L 369.706066 372.027431 
+L 386.78013 387.640603 
+L 404.42333 408.829908 
+L 421.497394 397.3059 
+L 439.140594 374.257884 
+L 456.783794 341.172828 
+L 473.857858 356.042516 
+L 491.501058 390.614541 
+L 508.575122 422.956112 
+L 526.218322 413.290815 
+L 543.861522 348.607672 
+L 559.797315 313.292163 
+L 577.440515 301.768155 
+L 594.514579 357.529485 
+L 612.157779 388.75583 
+L 629.231843 406.227713 
+L 646.875043 405.484229 
+L 664.518243 381.692728 
+L 681.592307 374.629626 
+L 699.235507 334.853211 
+L 716.309571 337.083664 
+L 733.952771 345.633735 
+L 751.595971 361.990391 
+L 768.1009 369.053493 
+L 785.7441 373.142657 
+L 802.818164 410.688619 
+L 820.461364 425.186565 
+L 837.535428 449.72155 
+L 855.178628 447.862839 
+L 872.821827 450.465035 
+L 889.895892 439.684511 
+L 907.539092 417.379979 
+L 924.613156 369.796978 
+L 942.256356 361.246907 
+L 959.899555 318.124812 
+L 975.835349 312.548679 
+L 993.478549 272.400521 
+L 1010.552613 267.939615 
+L 1028.195813 288.385436 
+L 1045.269877 294.333311 
+L 1062.913077 327.418367 
+L 1080.556277 321.098749 
+L 1097.630341 307.344288 
+L 1115.273541 296.192022 
+L 1132.347605 222.587067 
+L 1149.990805 201.026019 
+L 1167.634004 174.260581 
+L 1183.569798 193.219433 
+L 1201.212998 214.036996 
+L 1218.287062 221.843582 
+L 1235.930262 231.50888 
+L 1253.004326 208.832605 
+" clip-path="url(#pd2a7c7eff6)" style="fill: none; stroke: #10b981; stroke-width: 3; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_141"/>
+   <g id="line2d_142"/>
+   <g id="text_9">
+    <!-- v9.0 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(260.059773 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- v9.1 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(375.594275 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- v9.2 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(568.531202 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- v9.3 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(585.036131 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- v9.4 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(660.731149 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- v9.5 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(781.38787 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- v9.6 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(949.282836 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- v9.7 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(995.951945 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- v9.8 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1090.428434 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- v9.9 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1118.316072 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- v9.10 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1167.261723 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(218.212891 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- v9.11 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1211.654291 500.46436) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(218.212891 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_6">
+     <path d="M 105.826875 169.077923 
+L 419.939375 169.077923 
+Q 426.439375 169.077923 426.439375 162.577923 
+L 426.439375 118.796361 
+Q 426.439375 112.296361 419.939375 112.296361 
+L 105.826875 112.296361 
+Q 99.326875 112.296361 99.326875 118.796361 
+L 99.326875 162.577923 
+Q 99.326875 169.077923 105.826875 169.077923 
+z
+" style="fill: #ffffff; opacity: 0.98; stroke: #d1d5db; stroke-width: 2; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_143">
+     <path d="M 121.426875 139.72433 
+L 134.426875 139.72433 
+L 147.426875 139.72433 
+" style="fill: none; stroke: #0066cc; stroke-width: 3; stroke-linecap: round"/>
+    </g>
+    <g id="text_21">
+     <!-- GNU coreutils -->
+     <g style="fill: #262626" transform="translate(157.826875 144.27433) scale(0.13 -0.13)">
+      <defs>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 556 4666 
+L 1191 4666 
+L 1191 1831 
+Q 1191 1081 1462 751 
+Q 1734 422 2344 422 
+Q 2950 422 3222 751 
+Q 3494 1081 3494 1831 
+L 3494 4666 
+L 4128 4666 
+L 4128 1753 
+Q 4128 841 3676 375 
+Q 3225 -91 2344 -91 
+Q 1459 -91 1007 375 
+Q 556 841 556 1753 
+L 556 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(77.490234 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(152.294922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.488281 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(257.275391 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(312.255859 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(373.4375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(412.300781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(473.824219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(537.203125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(576.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(604.195312 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(631.978516 0)"/>
+     </g>
+    </g>
+    <g id="line2d_144">
+     <path d="M 272.755 139.72433 
+L 285.755 139.72433 
+L 298.755 139.72433 
+" style="fill: none; stroke: #10b981; stroke-width: 3; stroke-linecap: round"/>
+    </g>
+    <g id="text_22">
+     <!-- uutils coreutils -->
+     <g style="fill: #262626" transform="translate(309.155 144.27433) scale(0.13 -0.13)">
+      <use xlink:href="#DejaVuSans-75"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(63.378906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(126.757812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(165.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(193.75 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(221.533203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(273.632812 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(305.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(360.400391 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(421.582031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(460.445312 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(521.96875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(585.347656 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(624.556641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(652.339844 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(680.123047 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 99.326875 930.906667 
+L 1264.426875 930.906667 
+L 1264.426875 550.698039 
+L 99.326875 550.698039 
+z
+" style="fill: #fafafa; opacity: 0.6"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 99.326875 930.906667 
+L 1264.426875 930.906667 
+L 1264.426875 550.698039 
+L 99.326875 550.698039 
+L 99.326875 930.906667 
+z
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-width: 3; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_29">
+     <g id="line2d_145">
+      <path d="M 110.749424 930.906667 
+L 110.749424 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#me259dc2b60" x="110.749424" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_147">
+      <path d="M 318.483873 930.906667 
+L 318.483873 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#me259dc2b60" x="318.483873" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_149">
+      <path d="M 526.218322 930.906667 
+L 526.218322 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#me259dc2b60" x="526.218322" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_151">
+      <path d="M 733.952771 930.906667 
+L 733.952771 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#me259dc2b60" x="733.952771" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_153">
+      <path d="M 942.256356 930.906667 
+L 942.256356 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#me259dc2b60" x="942.256356" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_155">
+      <path d="M 1149.990805 930.906667 
+L 1149.990805 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#me259dc2b60" x="1149.990805" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_157">
+      <path d="M 162.82532 930.906667 
+L 162.82532 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="162.82532" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_159">
+      <path d="M 214.901216 930.906667 
+L 214.901216 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="214.901216" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_161">
+      <path d="M 266.977112 930.906667 
+L 266.977112 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="266.977112" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_163">
+      <path d="M 319.053009 930.906667 
+L 319.053009 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_164">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="319.053009" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_165">
+      <path d="M 371.128905 930.906667 
+L 371.128905 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_166">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="371.128905" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_167">
+      <path d="M 423.204801 930.906667 
+L 423.204801 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_168">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="423.204801" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_169">
+      <path d="M 475.280697 930.906667 
+L 475.280697 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_170">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="475.280697" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_171">
+      <path d="M 527.356593 930.906667 
+L 527.356593 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_172">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="527.356593" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_173">
+      <path d="M 579.432489 930.906667 
+L 579.432489 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_174">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="579.432489" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_175">
+      <path d="M 631.508385 930.906667 
+L 631.508385 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_176">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="631.508385" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_177">
+      <path d="M 683.584281 930.906667 
+L 683.584281 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_178">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="683.584281" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_179">
+      <path d="M 735.660178 930.906667 
+L 735.660178 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_180">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="735.660178" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_181">
+      <path d="M 787.736074 930.906667 
+L 787.736074 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_182">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="787.736074" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_183">
+      <path d="M 839.81197 930.906667 
+L 839.81197 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_184">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="839.81197" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_185">
+      <path d="M 891.887866 930.906667 
+L 891.887866 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_186">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="891.887866" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_187">
+      <path d="M 943.963762 930.906667 
+L 943.963762 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_188">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="943.963762" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_189">
+      <path d="M 996.039658 930.906667 
+L 996.039658 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_190">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="996.039658" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_191">
+      <path d="M 1048.115554 930.906667 
+L 1048.115554 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_192">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1048.115554" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_193">
+      <path d="M 1100.19145 930.906667 
+L 1100.19145 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_194">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1100.19145" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_195">
+      <path d="M 1152.267347 930.906667 
+L 1152.267347 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_196">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1152.267347" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_197">
+      <path d="M 1204.343243 930.906667 
+L 1204.343243 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_198">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1204.343243" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_199">
+      <path d="M 1256.419139 930.906667 
+L 1256.419139 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_200">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1256.419139" y="938.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_36">
+     <g id="line2d_201">
+      <path d="M 99.326875 930.906667 
+L 1264.426875 930.906667 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_202">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="930.906667" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 0 -->
+      <g style="fill: #555555" transform="translate(68.32875 937.175378) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_203">
+      <path d="M 99.326875 860.268742 
+L 1264.426875 860.268742 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_204">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="860.268742" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 10 -->
+      <g style="fill: #555555" transform="translate(57.830625 866.537453) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_205">
+      <path d="M 99.326875 789.630818 
+L 1264.426875 789.630818 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_206">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="789.630818" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 20 -->
+      <g style="fill: #555555" transform="translate(57.830625 795.899529) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_207">
+      <path d="M 99.326875 718.992894 
+L 1264.426875 718.992894 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_208">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="718.992894" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 30 -->
+      <g style="fill: #555555" transform="translate(57.830625 725.261605) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_209">
+      <path d="M 99.326875 648.35497 
+L 1264.426875 648.35497 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_210">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="648.35497" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 40 -->
+      <g style="fill: #555555" transform="translate(57.830625 654.62368) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_211">
+      <path d="M 99.326875 577.717045 
+L 1264.426875 577.717045 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_212">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="577.717045" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 50 -->
+      <g style="fill: #555555" transform="translate(57.830625 583.985756) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_213">
+      <path d="M 99.326875 916.779082 
+L 1264.426875 916.779082 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_214">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="916.779082" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_215">
+      <path d="M 99.326875 902.651497 
+L 1264.426875 902.651497 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_216">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="902.651497" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_217">
+      <path d="M 99.326875 888.523912 
+L 1264.426875 888.523912 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_218">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="888.523912" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_219">
+      <path d="M 99.326875 874.396327 
+L 1264.426875 874.396327 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_220">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="874.396327" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_221">
+      <path d="M 99.326875 846.141158 
+L 1264.426875 846.141158 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_222">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="846.141158" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_223">
+      <path d="M 99.326875 832.013573 
+L 1264.426875 832.013573 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_224">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="832.013573" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_225">
+      <path d="M 99.326875 817.885988 
+L 1264.426875 817.885988 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_226">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="817.885988" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_227">
+      <path d="M 99.326875 803.758403 
+L 1264.426875 803.758403 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_228">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="803.758403" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_229">
+      <path d="M 99.326875 775.503233 
+L 1264.426875 775.503233 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_230">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="775.503233" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_231">
+      <path d="M 99.326875 761.375648 
+L 1264.426875 761.375648 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_232">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="761.375648" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_233">
+      <path d="M 99.326875 747.248064 
+L 1264.426875 747.248064 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_234">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="747.248064" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_235">
+      <path d="M 99.326875 733.120479 
+L 1264.426875 733.120479 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_236">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="733.120479" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_237">
+      <path d="M 99.326875 704.865309 
+L 1264.426875 704.865309 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_238">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="704.865309" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_239">
+      <path d="M 99.326875 690.737724 
+L 1264.426875 690.737724 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_240">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="690.737724" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_241">
+      <path d="M 99.326875 676.610139 
+L 1264.426875 676.610139 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_242">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="676.610139" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_57">
+     <g id="line2d_243">
+      <path d="M 99.326875 662.482554 
+L 1264.426875 662.482554 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_244">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="662.482554" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_58">
+     <g id="line2d_245">
+      <path d="M 99.326875 634.227385 
+L 1264.426875 634.227385 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_246">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="634.227385" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_59">
+     <g id="line2d_247">
+      <path d="M 99.326875 620.0998 
+L 1264.426875 620.0998 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_248">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="620.0998" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_60">
+     <g id="line2d_249">
+      <path d="M 99.326875 605.972215 
+L 1264.426875 605.972215 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_250">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="605.972215" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_61">
+     <g id="line2d_251">
+      <path d="M 99.326875 591.84463 
+L 1264.426875 591.84463 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_252">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="591.84463" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_62">
+     <g id="line2d_253">
+      <path d="M 99.326875 563.58946 
+L 1264.426875 563.58946 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_254">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="563.58946" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_29">
+     <!-- Active contributors / month -->
+     <g style="fill: #374151" transform="translate(39.711094 857.387509) rotate(-90) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-Bold-41" d="M 3419 850 
+L 1538 850 
+L 1241 0 
+L 31 0 
+L 1759 4666 
+L 3194 4666 
+L 4922 0 
+L 3713 0 
+L 3419 850 
+z
+M 1838 1716 
+L 3116 1716 
+L 2478 3572 
+L 1838 1716 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-75" d="M 500 1363 
+L 500 3500 
+L 1625 3500 
+L 1625 3150 
+Q 1625 2866 1622 2436 
+Q 1619 2006 1619 1863 
+Q 1619 1441 1641 1255 
+Q 1663 1069 1716 984 
+Q 1784 875 1895 815 
+Q 2006 756 2150 756 
+Q 2500 756 2700 1025 
+Q 2900 1294 2900 1772 
+L 2900 3500 
+L 4019 3500 
+L 4019 0 
+L 2900 0 
+L 2900 506 
+Q 2647 200 2364 54 
+Q 2081 -91 1741 -91 
+Q 1134 -91 817 281 
+Q 500 653 500 1363 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Bold-41"/>
+      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(77.392578 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(136.669922 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(184.472656 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-76" transform="translate(218.75 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(283.935547 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(351.757812 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(386.572266 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(445.849609 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(514.550781 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(585.742188 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-72" transform="translate(633.544922 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(682.861328 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-62" transform="translate(717.138672 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-75" transform="translate(788.720703 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(859.912109 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(907.714844 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-72" transform="translate(976.416016 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1025.732422 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1085.253906 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(1120.068359 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1156.591797 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1191.40625 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1295.605469 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1364.306641 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1435.498047 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-68" transform="translate(1483.300781 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_3"/>
+   <g id="FillBetweenPolyCollection_4"/>
+   <g id="line2d_255">
+    <path d="M 262.139461 930.906667 
+L 262.139461 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_256">
+    <path d="M 377.673963 930.906667 
+L 377.673963 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_257">
+    <path d="M 570.610889 930.906667 
+L 570.610889 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_258">
+    <path d="M 587.115818 930.906667 
+L 587.115818 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_259">
+    <path d="M 662.810837 930.906667 
+L 662.810837 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_260">
+    <path d="M 783.467558 930.906667 
+L 783.467558 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_261">
+    <path d="M 951.362523 930.906667 
+L 951.362523 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_262">
+    <path d="M 998.031632 930.906667 
+L 998.031632 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_263">
+    <path d="M 1092.508122 930.906667 
+L 1092.508122 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_264">
+    <path d="M 1120.39576 930.906667 
+L 1120.39576 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_265">
+    <path d="M 1169.341411 930.906667 
+L 1169.341411 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_266">
+    <path d="M 1213.733978 930.906667 
+L 1213.733978 550.698039 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 91.326875 930.906667 
+L 91.326875 550.698039 
+" style="fill: none; stroke: #9ca3af; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 99.326875 938.906667 
+L 1264.426875 938.906667 
+" style="fill: none; stroke: #9ca3af; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_267">
+    <path d="M 110.749424 906.183393 
+L 128.392624 902.651497 
+L 144.328417 900.296899 
+L 161.971617 900.296899 
+L 179.045681 902.651497 
+L 196.688881 905.006094 
+L 213.762945 905.006094 
+L 231.406145 902.651497 
+L 249.049345 905.006094 
+L 266.123409 909.715289 
+L 283.766609 909.715289 
+L 300.840673 905.006094 
+L 318.483873 902.651497 
+L 336.127073 905.006094 
+L 352.062866 905.006094 
+L 369.706066 905.006094 
+L 386.78013 907.360692 
+L 404.42333 907.360692 
+L 421.497394 912.069887 
+L 439.140594 909.715289 
+L 456.783794 916.779082 
+L 473.857858 912.069887 
+L 491.501058 912.069887 
+L 508.575122 905.006094 
+L 526.218322 902.651497 
+L 543.861522 900.296899 
+L 559.797315 900.296899 
+L 577.440515 902.651497 
+L 594.514579 902.651497 
+L 612.157779 900.296899 
+L 629.231843 895.587705 
+L 646.875043 897.942302 
+L 664.518243 905.006094 
+L 681.592307 909.715289 
+L 699.235507 912.069887 
+L 716.309571 902.651497 
+L 733.952771 888.523912 
+L 751.595971 876.750925 
+L 768.1009 883.814717 
+L 785.7441 888.523912 
+L 802.818164 897.942302 
+L 820.461364 893.233107 
+L 837.535428 900.296899 
+L 855.178628 900.296899 
+L 872.821827 893.233107 
+L 889.895892 890.87851 
+L 907.539092 890.87851 
+L 924.613156 895.587705 
+L 942.256356 895.587705 
+L 959.899555 897.942302 
+L 975.835349 900.296899 
+L 993.478549 905.006094 
+L 1010.552613 900.296899 
+L 1028.195813 895.587705 
+L 1045.269877 890.87851 
+L 1062.913077 883.814717 
+L 1080.556277 886.169315 
+L 1097.630341 883.814717 
+L 1115.273541 890.87851 
+L 1132.347605 881.46012 
+L 1149.990805 876.750925 
+L 1167.634004 867.332535 
+L 1183.569798 872.04173 
+L 1201.212998 879.105522 
+L 1218.287062 893.233107 
+L 1235.930262 912.069887 
+L 1253.004326 920.310978 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #0066cc; stroke-width: 3; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_268">
+    <path d="M 110.749424 884.992016 
+L 128.392624 770.794038 
+L 144.328417 686.028529 
+L 161.971617 629.51819 
+L 179.045681 700.156114 
+L 196.688881 742.538869 
+L 213.762945 763.730246 
+L 231.406145 789.630818 
+L 249.049345 820.240585 
+L 266.123409 846.141158 
+L 283.766609 855.559547 
+L 300.840673 834.36817 
+L 318.483873 761.375648 
+L 336.127073 721.347491 
+L 352.062866 733.120479 
+L 369.706066 801.403805 
+L 386.78013 824.94978 
+L 404.42333 824.94978 
+L 421.497394 817.885988 
+L 439.140594 829.658975 
+L 456.783794 829.658975 
+L 473.857858 836.722768 
+L 491.501058 839.077365 
+L 508.575122 848.495755 
+L 526.218322 810.822195 
+L 543.861522 744.893466 
+L 559.797315 721.347491 
+L 577.440515 740.184271 
+L 594.514579 784.921623 
+L 612.157779 796.694611 
+L 629.231843 813.176793 
+L 646.875043 824.94978 
+L 664.518243 817.885988 
+L 681.592307 794.340013 
+L 699.235507 782.567026 
+L 716.309571 768.439441 
+L 733.952771 782.567026 
+L 751.595971 777.857831 
+L 768.1009 784.921623 
+L 785.7441 784.921623 
+L 802.818164 806.113 
+L 820.461364 817.885988 
+L 837.535428 846.141158 
+L 855.178628 841.431963 
+L 872.821827 834.36817 
+L 889.895892 827.304378 
+L 907.539092 813.176793 
+L 924.613156 808.467598 
+L 942.256356 787.276221 
+L 959.899555 759.021051 
+L 975.835349 733.120479 
+L 993.478549 704.865309 
+L 1010.552613 716.638296 
+L 1028.195813 749.602661 
+L 1045.269877 796.694611 
+L 1062.913077 791.985416 
+L 1080.556277 775.503233 
+L 1097.630341 735.475076 
+L 1115.273541 718.992894 
+L 1132.347605 631.872787 
+L 1149.990805 568.298655 
+L 1167.634004 573.00785 
+L 1183.569798 634.227385 
+L 1201.212998 678.964737 
+L 1218.287062 686.028529 
+L 1235.930262 636.581982 
+L 1253.004326 613.036007 
+" clip-path="url(#p2da38cfa41)" style="fill: none; stroke: #10b981; stroke-width: 3; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_269"/>
+   <g id="line2d_270"/>
+   <g id="text_30">
+    <!-- v9.0 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(260.059773 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- v9.1 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(375.594275 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- v9.2 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(568.531202 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- v9.3 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(585.036131 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- v9.4 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(660.731149 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- v9.5 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(781.38787 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- v9.6 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(949.282836 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- v9.7 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(995.951945 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- v9.8 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1090.428434 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- v9.9 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1118.316072 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- v9.10 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1167.261723 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(218.212891 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- v9.11 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1211.654291 923.654506) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(218.212891 0)"/>
+    </g>
+   </g>
+   <g id="legend_2">
+    <g id="patch_11">
+     <path d="M 105.826875 592.271257 
+L 419.939375 592.271257 
+Q 426.439375 592.271257 426.439375 585.771257 
+L 426.439375 541.989694 
+Q 426.439375 535.489694 419.939375 535.489694 
+L 105.826875 535.489694 
+Q 99.326875 535.489694 99.326875 541.989694 
+L 99.326875 585.771257 
+Q 99.326875 592.271257 105.826875 592.271257 
+z
+" style="fill: #ffffff; opacity: 0.98; stroke: #d1d5db; stroke-width: 2; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_271">
+     <path d="M 121.426875 562.917663 
+L 134.426875 562.917663 
+L 147.426875 562.917663 
+" style="fill: none; stroke: #0066cc; stroke-width: 3; stroke-linecap: round"/>
+    </g>
+    <g id="text_42">
+     <!-- GNU coreutils -->
+     <g style="fill: #262626" transform="translate(157.826875 567.467663) scale(0.13 -0.13)">
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(77.490234 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(152.294922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.488281 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(257.275391 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(312.255859 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(373.4375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(412.300781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(473.824219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(537.203125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(576.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(604.195312 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(631.978516 0)"/>
+     </g>
+    </g>
+    <g id="line2d_272">
+     <path d="M 272.755 562.917663 
+L 285.755 562.917663 
+L 298.755 562.917663 
+" style="fill: none; stroke: #10b981; stroke-width: 3; stroke-linecap: round"/>
+    </g>
+    <g id="text_43">
+     <!-- uutils coreutils -->
+     <g style="fill: #262626" transform="translate(309.155 567.467663) scale(0.13 -0.13)">
+      <use xlink:href="#DejaVuSans-75"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(63.378906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(126.757812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(165.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(193.75 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(221.533203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(273.632812 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(305.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(360.400391 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(421.582031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(460.445312 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(521.96875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(585.347656 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(624.556641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(652.339844 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(680.123047 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 99.326875 1354.1 
+L 1264.426875 1354.1 
+L 1264.426875 973.891373 
+L 99.326875 973.891373 
+z
+" style="fill: #fafafa; opacity: 0.6"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 99.326875 1354.1 
+L 1264.426875 1354.1 
+L 1264.426875 973.891373 
+L 99.326875 973.891373 
+L 99.326875 1354.1 
+z
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-width: 3; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_57">
+     <g id="line2d_273">
+      <path d="M 110.749424 1354.1 
+L 110.749424 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_274">
+      <g>
+       <use xlink:href="#me259dc2b60" x="110.749424" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <!-- 2021 -->
+      <g style="fill: #555555" transform="translate(89.753174 1387.137422) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_275">
+      <path d="M 318.483873 1354.1 
+L 318.483873 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_276">
+      <g>
+       <use xlink:href="#me259dc2b60" x="318.483873" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_45">
+      <!-- 2022 -->
+      <g style="fill: #555555" transform="translate(297.487623 1387.137422) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_59">
+     <g id="line2d_277">
+      <path d="M 526.218322 1354.1 
+L 526.218322 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_278">
+      <g>
+       <use xlink:href="#me259dc2b60" x="526.218322" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_46">
+      <!-- 2023 -->
+      <g style="fill: #555555" transform="translate(505.222072 1387.137422) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_60">
+     <g id="line2d_279">
+      <path d="M 733.952771 1354.1 
+L 733.952771 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_280">
+      <g>
+       <use xlink:href="#me259dc2b60" x="733.952771" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_47">
+      <!-- 2024 -->
+      <g style="fill: #555555" transform="translate(712.956521 1387.137422) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_61">
+     <g id="line2d_281">
+      <path d="M 942.256356 1354.1 
+L 942.256356 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_282">
+      <g>
+       <use xlink:href="#me259dc2b60" x="942.256356" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_48">
+      <!-- 2025 -->
+      <g style="fill: #555555" transform="translate(921.260106 1387.137422) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_62">
+     <g id="line2d_283">
+      <path d="M 1149.990805 1354.1 
+L 1149.990805 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_284">
+      <g>
+       <use xlink:href="#me259dc2b60" x="1149.990805" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_49">
+      <!-- 2026 -->
+      <g style="fill: #555555" transform="translate(1128.994555 1387.137422) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_63">
+     <g id="line2d_285">
+      <path d="M 162.82532 1354.1 
+L 162.82532 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_286">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="162.82532" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_64">
+     <g id="line2d_287">
+      <path d="M 214.901216 1354.1 
+L 214.901216 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_288">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="214.901216" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_65">
+     <g id="line2d_289">
+      <path d="M 266.977112 1354.1 
+L 266.977112 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_290">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="266.977112" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_66">
+     <g id="line2d_291">
+      <path d="M 319.053009 1354.1 
+L 319.053009 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_292">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="319.053009" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_67">
+     <g id="line2d_293">
+      <path d="M 371.128905 1354.1 
+L 371.128905 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_294">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="371.128905" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_68">
+     <g id="line2d_295">
+      <path d="M 423.204801 1354.1 
+L 423.204801 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_296">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="423.204801" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_69">
+     <g id="line2d_297">
+      <path d="M 475.280697 1354.1 
+L 475.280697 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_298">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="475.280697" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_70">
+     <g id="line2d_299">
+      <path d="M 527.356593 1354.1 
+L 527.356593 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_300">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="527.356593" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_71">
+     <g id="line2d_301">
+      <path d="M 579.432489 1354.1 
+L 579.432489 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_302">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="579.432489" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_72">
+     <g id="line2d_303">
+      <path d="M 631.508385 1354.1 
+L 631.508385 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_304">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="631.508385" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_73">
+     <g id="line2d_305">
+      <path d="M 683.584281 1354.1 
+L 683.584281 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_306">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="683.584281" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_74">
+     <g id="line2d_307">
+      <path d="M 735.660178 1354.1 
+L 735.660178 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_308">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="735.660178" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_75">
+     <g id="line2d_309">
+      <path d="M 787.736074 1354.1 
+L 787.736074 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_310">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="787.736074" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_76">
+     <g id="line2d_311">
+      <path d="M 839.81197 1354.1 
+L 839.81197 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_312">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="839.81197" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_77">
+     <g id="line2d_313">
+      <path d="M 891.887866 1354.1 
+L 891.887866 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_314">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="891.887866" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_78">
+     <g id="line2d_315">
+      <path d="M 943.963762 1354.1 
+L 943.963762 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_316">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="943.963762" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_79">
+     <g id="line2d_317">
+      <path d="M 996.039658 1354.1 
+L 996.039658 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_318">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="996.039658" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_80">
+     <g id="line2d_319">
+      <path d="M 1048.115554 1354.1 
+L 1048.115554 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_320">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1048.115554" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_81">
+     <g id="line2d_321">
+      <path d="M 1100.19145 1354.1 
+L 1100.19145 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_322">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1100.19145" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_82">
+     <g id="line2d_323">
+      <path d="M 1152.267347 1354.1 
+L 1152.267347 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_324">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1152.267347" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_83">
+     <g id="line2d_325">
+      <path d="M 1204.343243 1354.1 
+L 1204.343243 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_326">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1204.343243" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_84">
+     <g id="line2d_327">
+      <path d="M 1256.419139 1354.1 
+L 1256.419139 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_328">
+      <g>
+       <use xlink:href="#m3a3fa2f38c" x="1256.419139" y="1362.1" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_50">
+     <!-- Date -->
+     <g style="fill: #374151" transform="translate(661.9175 1416.966562) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-Bold-44" d="M 1791 3756 
+L 1791 909 
+L 2222 909 
+Q 2959 909 3348 1275 
+Q 3738 1641 3738 2338 
+Q 3738 3031 3350 3393 
+Q 2963 3756 2222 3756 
+L 1791 3756 
+z
+M 588 4666 
+L 1856 4666 
+Q 2919 4666 3439 4514 
+Q 3959 4363 4331 4000 
+Q 4659 3684 4818 3271 
+Q 4978 2859 4978 2338 
+Q 4978 1809 4818 1395 
+Q 4659 981 4331 666 
+Q 3956 303 3431 151 
+Q 2906 0 1856 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Bold-44"/>
+      <use xlink:href="#DejaVuSans-Bold-61" transform="translate(83.007812 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(150.488281 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(198.291016 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_63">
+     <g id="line2d_329">
+      <path d="M 99.326875 1354.1 
+L 1264.426875 1354.1 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_330">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="1354.1" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_51">
+      <!-- 0 -->
+      <g style="fill: #555555" transform="translate(68.32875 1360.368711) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_64">
+     <g id="line2d_331">
+      <path d="M 99.326875 1278.312164 
+L 1264.426875 1278.312164 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_332">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="1278.312164" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_52">
+      <!-- 200 -->
+      <g style="fill: #555555" transform="translate(47.3325 1284.580875) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_65">
+     <g id="line2d_333">
+      <path d="M 99.326875 1202.524328 
+L 1264.426875 1202.524328 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_334">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="1202.524328" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_53">
+      <!-- 400 -->
+      <g style="fill: #555555" transform="translate(47.3325 1208.793038) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_66">
+     <g id="line2d_335">
+      <path d="M 99.326875 1126.736491 
+L 1264.426875 1126.736491 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_336">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="1126.736491" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_54">
+      <!-- 600 -->
+      <g style="fill: #555555" transform="translate(47.3325 1133.005202) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_67">
+     <g id="line2d_337">
+      <path d="M 99.326875 1050.948655 
+L 1264.426875 1050.948655 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_338">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="1050.948655" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_55">
+      <!-- 800 -->
+      <g style="fill: #555555" transform="translate(47.3325 1057.217366) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_68">
+     <g id="line2d_339">
+      <path d="M 99.326875 975.160819 
+L 1264.426875 975.160819 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #e5e7eb; stroke-opacity: 0.35; stroke-linecap: round"/>
+     </g>
+     <g id="line2d_340">
+      <g>
+       <use xlink:href="#m07c430eed5" x="91.326875" y="975.160819" style="fill: #555555; stroke: #555555; stroke-width: 1.875"/>
+      </g>
+     </g>
+     <g id="text_56">
+      <!-- 1000 -->
+      <g style="fill: #555555" transform="translate(36.834375 981.42953) scale(0.165 -0.165)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_69">
+     <g id="line2d_341">
+      <path d="M 99.326875 1335.153041 
+L 1264.426875 1335.153041 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_342">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1335.153041" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_70">
+     <g id="line2d_343">
+      <path d="M 99.326875 1316.206082 
+L 1264.426875 1316.206082 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_344">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1316.206082" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_71">
+     <g id="line2d_345">
+      <path d="M 99.326875 1297.259123 
+L 1264.426875 1297.259123 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_346">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1297.259123" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_72">
+     <g id="line2d_347">
+      <path d="M 99.326875 1259.365205 
+L 1264.426875 1259.365205 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_348">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1259.365205" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_73">
+     <g id="line2d_349">
+      <path d="M 99.326875 1240.418246 
+L 1264.426875 1240.418246 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_350">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1240.418246" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_74">
+     <g id="line2d_351">
+      <path d="M 99.326875 1221.471287 
+L 1264.426875 1221.471287 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_352">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1221.471287" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_75">
+     <g id="line2d_353">
+      <path d="M 99.326875 1183.577368 
+L 1264.426875 1183.577368 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_354">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1183.577368" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_76">
+     <g id="line2d_355">
+      <path d="M 99.326875 1164.630409 
+L 1264.426875 1164.630409 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_356">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1164.630409" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_77">
+     <g id="line2d_357">
+      <path d="M 99.326875 1145.68345 
+L 1264.426875 1145.68345 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_358">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1145.68345" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_78">
+     <g id="line2d_359">
+      <path d="M 99.326875 1107.789532 
+L 1264.426875 1107.789532 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_360">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1107.789532" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_79">
+     <g id="line2d_361">
+      <path d="M 99.326875 1088.842573 
+L 1264.426875 1088.842573 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_362">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1088.842573" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_80">
+     <g id="line2d_363">
+      <path d="M 99.326875 1069.895614 
+L 1264.426875 1069.895614 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_364">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1069.895614" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_81">
+     <g id="line2d_365">
+      <path d="M 99.326875 1032.001696 
+L 1264.426875 1032.001696 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_366">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1032.001696" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_82">
+     <g id="line2d_367">
+      <path d="M 99.326875 1013.054737 
+L 1264.426875 1013.054737 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_368">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="1013.054737" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_83">
+     <g id="line2d_369">
+      <path d="M 99.326875 994.107778 
+L 1264.426875 994.107778 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 0.5,0.825; stroke-dashoffset: 0; stroke: #f3f4f6; stroke-opacity: 0.15; stroke-width: 0.5"/>
+     </g>
+     <g id="line2d_370">
+      <g>
+       <use xlink:href="#m8b351d5d15" x="91.326875" y="994.107778" style="fill: #555555; stroke: #555555; stroke-width: 1.5"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_57">
+     <!-- Distinct contributors (since day 1) -->
+     <g style="fill: #374151" transform="translate(18.597656 1308.690608) rotate(-90) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Bold-44"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(83.007812 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-73" transform="translate(117.285156 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(176.806641 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(224.609375 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(258.886719 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(330.078125 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(389.355469 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(437.158203 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(471.972656 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(531.25 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(599.951172 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(671.142578 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-72" transform="translate(718.945312 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(768.261719 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-62" transform="translate(802.539062 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-75" transform="translate(874.121094 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(945.3125 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(993.115234 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1061.816406 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1111.132812 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1170.654297 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-28" transform="translate(1205.46875 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1251.171875 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1310.693359 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1344.970703 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(1416.162109 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1475.439453 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1543.261719 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1578.076172 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1649.658203 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-79" transform="translate(1714.013672 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1779.199219 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-31" transform="translate(1814.013672 0)"/>
+      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(1883.59375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_5"/>
+   <g id="FillBetweenPolyCollection_6"/>
+   <g id="line2d_371">
+    <path d="M 262.139461 1354.1 
+L 262.139461 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_372">
+    <path d="M 377.673963 1354.1 
+L 377.673963 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_373">
+    <path d="M 570.610889 1354.1 
+L 570.610889 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_374">
+    <path d="M 587.115818 1354.1 
+L 587.115818 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_375">
+    <path d="M 662.810837 1354.1 
+L 662.810837 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_376">
+    <path d="M 783.467558 1354.1 
+L 783.467558 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_377">
+    <path d="M 951.362523 1354.1 
+L 951.362523 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_378">
+    <path d="M 998.031632 1354.1 
+L 998.031632 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_379">
+    <path d="M 1092.508122 1354.1 
+L 1092.508122 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_380">
+    <path d="M 1120.39576 1354.1 
+L 1120.39576 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_381">
+    <path d="M 1169.341411 1354.1 
+L 1169.341411 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_382">
+    <path d="M 1213.733978 1354.1 
+L 1213.733978 973.891373 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #6b7280; stroke-opacity: 0.6; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 91.326875 1354.1 
+L 91.326875 973.891373 
+" style="fill: none; stroke: #9ca3af; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 99.326875 1362.1 
+L 1264.426875 1362.1 
+" style="fill: none; stroke: #9ca3af; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_383">
+    <path d="M 110.749424 1262.396718 
+L 128.392624 1262.396718 
+L 144.328417 1262.017779 
+L 161.971617 1261.63884 
+L 179.045681 1261.63884 
+L 196.688881 1261.259901 
+L 213.762945 1260.880961 
+L 231.406145 1260.880961 
+L 249.049345 1260.123083 
+L 266.123409 1260.123083 
+L 283.766609 1260.123083 
+L 300.840673 1259.744144 
+L 318.483873 1258.986266 
+L 336.127073 1258.986266 
+L 352.062866 1258.228387 
+L 369.706066 1258.228387 
+L 386.78013 1258.228387 
+L 404.42333 1258.228387 
+L 421.497394 1257.470509 
+L 439.140594 1257.470509 
+L 456.783794 1256.71263 
+L 473.857858 1256.71263 
+L 491.501058 1256.333691 
+L 508.575122 1255.954752 
+L 526.218322 1255.954752 
+L 543.861522 1255.575813 
+L 559.797315 1255.575813 
+L 577.440515 1255.196874 
+L 594.514579 1255.196874 
+L 612.157779 1254.817935 
+L 629.231843 1254.817935 
+L 646.875043 1254.438995 
+L 664.518243 1254.060056 
+L 681.592307 1254.060056 
+L 699.235507 1253.681117 
+L 716.309571 1253.302178 
+L 733.952771 1252.16536 
+L 751.595971 1249.891725 
+L 768.1009 1249.512786 
+L 785.7441 1249.512786 
+L 802.818164 1248.754908 
+L 820.461364 1248.754908 
+L 837.535428 1248.754908 
+L 855.178628 1248.375968 
+L 872.821827 1248.375968 
+L 889.895892 1247.61809 
+L 907.539092 1247.239151 
+L 924.613156 1246.860212 
+L 942.256356 1246.481273 
+L 959.899555 1246.481273 
+L 975.835349 1246.102333 
+L 993.478549 1246.102333 
+L 1010.552613 1246.102333 
+L 1028.195813 1245.723394 
+L 1045.269877 1244.965516 
+L 1062.913077 1244.965516 
+L 1080.556277 1244.207637 
+L 1097.630341 1244.207637 
+L 1115.273541 1244.207637 
+L 1132.347605 1243.828698 
+L 1149.990805 1242.691881 
+L 1167.634004 1241.555063 
+L 1183.569798 1240.797185 
+L 1201.212998 1240.418246 
+L 1218.287062 1240.418246 
+L 1235.930262 1240.418246 
+L 1253.004326 1240.418246 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #0066cc; stroke-width: 3; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_384">
+    <path d="M 110.749424 1271.112319 
+L 128.392624 1270.73338 
+L 144.328417 1252.923239 
+L 161.971617 1244.586577 
+L 179.045681 1240.418246 
+L 196.688881 1236.249915 
+L 213.762945 1233.59734 
+L 231.406145 1230.944766 
+L 249.049345 1229.807949 
+L 266.123409 1229.05007 
+L 283.766609 1228.671131 
+L 300.840673 1226.776435 
+L 318.483873 1222.608104 
+L 336.127073 1211.239929 
+L 352.062866 1208.587354 
+L 369.706066 1206.313719 
+L 386.78013 1205.555841 
+L 404.42333 1201.766449 
+L 421.497394 1199.871753 
+L 439.140594 1197.598118 
+L 456.783794 1196.082361 
+L 473.857858 1194.945544 
+L 491.501058 1193.808726 
+L 508.575122 1192.29297 
+L 526.218322 1191.91403 
+L 543.861522 1184.714186 
+L 559.797315 1175.619646 
+L 577.440515 1170.693436 
+L 594.514579 1168.419801 
+L 612.157779 1163.493592 
+L 629.231843 1162.356774 
+L 646.875043 1159.7042 
+L 664.518243 1157.809504 
+L 681.592307 1153.641173 
+L 699.235507 1148.336025 
+L 716.309571 1143.788754 
+L 733.952771 1138.104667 
+L 751.595971 1135.831032 
+L 768.1009 1131.283761 
+L 785.7441 1127.11543 
+L 802.818164 1124.462856 
+L 820.461364 1122.56816 
+L 837.535428 1119.915586 
+L 855.178628 1119.536647 
+L 872.821827 1116.884073 
+L 889.895892 1113.852559 
+L 907.539092 1113.094681 
+L 924.613156 1108.92635 
+L 942.256356 1105.515897 
+L 959.899555 1102.484384 
+L 975.835349 1095.284539 
+L 993.478549 1088.084695 
+L 1010.552613 1083.916364 
+L 1028.195813 1078.232276 
+L 1045.269877 1075.200763 
+L 1062.913077 1074.063945 
+L 1080.556277 1065.727283 
+L 1097.630341 1060.801074 
+L 1115.273541 1057.390621 
+L 1132.347605 1052.085473 
+L 1149.990805 1038.822601 
+L 1167.634004 1027.833365 
+L 1183.569798 1021.770338 
+L 1201.212998 1014.570494 
+L 1218.287062 1008.507467 
+L 1235.930262 1001.307622 
+L 1253.004326 988.044751 
+" clip-path="url(#p221d2e5d59)" style="fill: none; stroke: #10b981; stroke-width: 3; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_385"/>
+   <g id="line2d_386"/>
+   <g id="text_58">
+    <!-- v9.0 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(260.059773 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_59">
+    <!-- v9.1 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(375.594275 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_60">
+    <!-- v9.2 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(568.531202 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_61">
+    <!-- v9.3 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(585.036131 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_62">
+    <!-- v9.4 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(660.731149 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_63">
+    <!-- v9.5 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(781.38787 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_64">
+    <!-- v9.6 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(949.282836 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_65">
+    <!-- v9.7 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(995.951945 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_66">
+    <!-- v9.8 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1090.428434 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_67">
+    <!-- v9.9 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1118.316072 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(154.589844 0)"/>
+    </g>
+   </g>
+   <g id="text_68">
+    <!-- v9.10 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1167.261723 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(218.212891 0)"/>
+    </g>
+   </g>
+   <g id="text_69">
+    <!-- v9.11 -->
+    <g style="fill: #374151; opacity: 0.85" transform="translate(1211.654291 1346.778895) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-76"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(59.179688 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(122.802734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(154.589844 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(218.212891 0)"/>
+    </g>
+   </g>
+   <g id="legend_3">
+    <g id="patch_16">
+     <path d="M 105.826875 1015.46459 
+L 419.939375 1015.46459 
+Q 426.439375 1015.46459 426.439375 1008.96459 
+L 426.439375 965.183027 
+Q 426.439375 958.683027 419.939375 958.683027 
+L 105.826875 958.683027 
+Q 99.326875 958.683027 99.326875 965.183027 
+L 99.326875 1008.96459 
+Q 99.326875 1015.46459 105.826875 1015.46459 
+z
+" style="fill: #ffffff; opacity: 0.98; stroke: #d1d5db; stroke-width: 2; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_387">
+     <path d="M 121.426875 986.110996 
+L 134.426875 986.110996 
+L 147.426875 986.110996 
+" style="fill: none; stroke: #0066cc; stroke-width: 3; stroke-linecap: round"/>
+    </g>
+    <g id="text_70">
+     <!-- GNU coreutils -->
+     <g style="fill: #262626" transform="translate(157.826875 990.660996) scale(0.13 -0.13)">
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(77.490234 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(152.294922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.488281 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(257.275391 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(312.255859 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(373.4375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(412.300781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(473.824219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(537.203125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(576.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(604.195312 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(631.978516 0)"/>
+     </g>
+    </g>
+    <g id="line2d_388">
+     <path d="M 272.755 986.110996 
+L 285.755 986.110996 
+L 298.755 986.110996 
+" style="fill: none; stroke: #10b981; stroke-width: 3; stroke-linecap: round"/>
+    </g>
+    <g id="text_71">
+     <!-- uutils coreutils -->
+     <g style="fill: #262626" transform="translate(309.155 990.660996) scale(0.13 -0.13)">
+      <use xlink:href="#DejaVuSans-75"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(63.378906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(126.757812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(165.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(193.75 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(221.533203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(273.632812 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(305.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(360.400391 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(421.582031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(460.445312 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(521.96875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(585.347656 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(624.556641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(652.339844 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(680.123047 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_72">
+   <!-- GNU vs uutils coreutils — Development Activity Since 2021 -->
+   <g style="fill: #1a1a1a" transform="translate(203.726563 26.955938) scale(0.26 -0.26)">
+    <defs>
+     <path id="DejaVuSans-Bold-47" d="M 4781 347 
+Q 4331 128 3847 18 
+Q 3363 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3456 1012 4103 
+Q 1706 4750 2913 4750 
+Q 3378 4750 3804 4662 
+Q 4231 4575 4609 4403 
+L 4609 3438 
+Q 4219 3659 3833 3768 
+Q 3447 3878 3059 3878 
+Q 2341 3878 1952 3476 
+Q 1563 3075 1563 2328 
+Q 1563 1588 1938 1184 
+Q 2313 781 3003 781 
+Q 3191 781 3352 804 
+Q 3513 828 3641 878 
+L 3641 1784 
+L 2906 1784 
+L 2906 2591 
+L 4781 2591 
+L 4781 347 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-4e" d="M 588 4666 
+L 1931 4666 
+L 3628 1466 
+L 3628 4666 
+L 4769 4666 
+L 4769 0 
+L 3425 0 
+L 1728 3200 
+L 1728 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-55" d="M 588 4666 
+L 1791 4666 
+L 1791 1869 
+Q 1791 1291 1980 1042 
+Q 2169 794 2597 794 
+Q 3028 794 3217 1042 
+Q 3406 1291 3406 1869 
+L 3406 4666 
+L 4609 4666 
+L 4609 1869 
+Q 4609 878 4112 393 
+Q 3616 -91 2597 -91 
+Q 1581 -91 1084 393 
+Q 588 878 588 1869 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-53" d="M 3834 4519 
+L 3834 3531 
+Q 3450 3703 3084 3790 
+Q 2719 3878 2394 3878 
+Q 1963 3878 1756 3759 
+Q 1550 3641 1550 3391 
+Q 1550 3203 1689 3098 
+Q 1828 2994 2194 2919 
+L 2706 2816 
+Q 3484 2659 3812 2340 
+Q 4141 2022 4141 1434 
+Q 4141 663 3683 286 
+Q 3225 -91 2284 -91 
+Q 1841 -91 1394 -6 
+Q 947 78 500 244 
+L 500 1259 
+Q 947 1022 1364 901 
+Q 1781 781 2169 781 
+Q 2563 781 2772 912 
+Q 2981 1044 2981 1288 
+Q 2981 1506 2839 1625 
+Q 2697 1744 2272 1838 
+L 1806 1941 
+Q 1106 2091 782 2419 
+Q 459 2747 459 3303 
+Q 459 4000 909 4375 
+Q 1359 4750 2203 4750 
+Q 2588 4750 2994 4692 
+Q 3400 4634 3834 4519 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-47"/>
+    <use xlink:href="#DejaVuSans-Bold-4e" transform="translate(82.080078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-55" transform="translate(165.771484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(246.972656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(281.787109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(346.972656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(406.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(441.308594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(512.5 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(583.691406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(631.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(665.771484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(700.048828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(759.570312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(794.384766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(853.662109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(922.363281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(971.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(1039.501953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1110.693359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1158.496094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1192.773438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1227.050781 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1286.572266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(1321.386719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1421.386719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-44" transform="translate(1456.201172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1539.208984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1607.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1672.216797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1740.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1774.316406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(1843.017578 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1914.599609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2018.798828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2086.621094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2157.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2205.615234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-41" transform="translate(2240.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(2317.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2377.099609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(2424.902344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(2459.179688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(2524.365234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2558.642578 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(2606.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-53" transform="translate(2706.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(2778.466797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2812.744141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(2883.935547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2943.212891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3011.035156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(3045.849609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(3115.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(3185.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(3254.589844 0)"/>
+   </g>
+  </g>
+  <g id="text_73">
+   <!-- Non-merge commits, bots excluded. Top two panels are 3-month rolling averages; the cumulative panel counts every contributor since each project's first commit. -->
+   <g style="fill: #6b7280; opacity: 0.9" transform="translate(104.231875 50.197969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Oblique-4e" d="M 1081 4666 
+L 1931 4666 
+L 3219 666 
+L 4000 4666 
+L 4616 4666 
+L 3706 0 
+L 2853 0 
+L 1569 4025 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6f" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6e" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2d" d="M 391 2009 
+L 2075 2009 
+L 1978 1497 
+L 288 1497 
+L 391 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6d" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-65" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-72" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-67" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-63" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-69" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-74" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-73" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2c" d="M 575 794 
+L 1234 794 
+L 1131 256 
+L 422 -744 
+L 19 -744 
+L 469 256 
+L 575 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-62" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-78" d="M 3841 3500 
+L 2234 1784 
+L 3219 0 
+L 2559 0 
+L 1819 1388 
+L 531 0 
+L -166 0 
+L 1556 1844 
+L 641 3500 
+L 1300 3500 
+L 1972 2234 
+L 3144 3500 
+L 3841 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6c" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-75" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-64" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-54" d="M 378 4666 
+L 4325 4666 
+L 4225 4134 
+L 2559 4134 
+L 1759 0 
+L 1125 0 
+L 1925 4134 
+L 275 4134 
+L 378 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-70" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-77" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-33" d="M 1013 4550 
+Q 1356 4650 1679 4700 
+Q 2003 4750 2316 4750 
+Q 2934 4750 3296 4475 
+Q 3659 4200 3659 3738 
+Q 3659 3284 3373 2959 
+Q 3088 2634 2584 2516 
+Q 2978 2403 3162 2165 
+Q 3347 1928 3347 1538 
+Q 3347 1163 3167 834 
+Q 2988 506 2650 269 
+Q 2394 88 2037 -1 
+Q 1681 -91 1216 -91 
+Q 922 -91 622 -33 
+Q 322 25 13 141 
+L 128 738 
+Q 422 575 720 495 
+Q 1019 416 1331 416 
+Q 1947 416 2330 733 
+Q 2713 1050 2713 1556 
+Q 2713 1881 2469 2057 
+Q 2225 2234 1772 2234 
+L 1228 2234 
+L 1325 2747 
+L 1900 2747 
+Q 2419 2747 2717 2984 
+Q 3016 3222 3016 3628 
+Q 3016 3922 2797 4083 
+Q 2578 4244 2181 4244 
+Q 1881 4244 1567 4180 
+Q 1253 4116 916 3988 
+L 1013 4550 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-68" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-76" d="M 459 3500 
+L 1069 3500 
+L 1581 525 
+L 3256 3500 
+L 3866 3500 
+L 1875 0 
+L 1100 0 
+L 459 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3b" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-79" d="M 1588 -325 
+Q 1188 -997 936 -1164 
+Q 684 -1331 294 -1331 
+L -159 -1331 
+L -63 -850 
+L 269 -850 
+Q 509 -850 678 -719 
+Q 847 -588 1056 -206 
+L 1234 128 
+L 459 3500 
+L 1069 3500 
+L 1650 819 
+L 3256 3500 
+L 3859 3500 
+L 1588 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6a" d="M 928 3500 
+L 1503 3500 
+L 813 -63 
+L 809 -78 
+Q 694 -675 544 -897 
+Q 403 -1106 132 -1218 
+Q -138 -1331 -506 -1331 
+L -722 -1331 
+L -628 -844 
+L -481 -844 
+Q -144 -844 -1 -703 
+Q 141 -563 238 -63 
+L 928 3500 
+z
+M 1197 4863 
+L 1772 4863 
+L 1631 4134 
+L 1056 4134 
+L 1197 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-27" d="M 1147 4666 
+L 1147 2931 
+L 616 2931 
+L 616 4666 
+L 1147 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-66" d="M 3059 4863 
+L 2969 4384 
+L 2419 4384 
+Q 2106 4384 1964 4261 
+Q 1822 4138 1753 3809 
+L 1691 3500 
+L 2638 3500 
+L 2553 3053 
+L 1606 3053 
+L 1013 0 
+L 434 0 
+L 1031 3053 
+L 481 3053 
+L 563 3500 
+L 1113 3500 
+L 1159 3744 
+Q 1278 4363 1576 4613 
+Q 1875 4863 2516 4863 
+L 3059 4863 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-4e"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(74.804688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(135.986328 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(199.365234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(235.449219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(332.861328 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(394.384766 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(435.498047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(498.974609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(560.498047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(592.285156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(647.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(708.447266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(805.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(903.271484 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(931.054688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(970.263672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2c" transform="translate(1022.363281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1054.150391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1085.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1149.414062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(1210.595703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1249.804688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1301.904297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1333.691406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(1395.214844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(1454.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1509.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1537.158203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1600.537109 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1664.013672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1725.537109 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(1789.013672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1820.800781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-54" transform="translate(1852.587891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1901.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1962.478516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2025.955078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(2057.742188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(2096.951172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(2178.738281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2239.919922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2271.707031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(2335.183594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(2396.462891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2459.841797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(2521.365234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2549.148438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2601.248047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(2633.035156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2694.314453 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2735.427734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2796.951172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-33" transform="translate(2828.738281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(2892.361328 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(2928.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3025.857422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(3087.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3150.417969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(3189.626953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3253.005859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(3284.792969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3325.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(3387.087891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(3414.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3442.654297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(3470.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(3533.816406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3597.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(3629.080078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-76" transform="translate(3690.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3749.539062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(3811.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(3852.175781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(3913.455078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3976.931641 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4038.455078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3b" transform="translate(4090.554688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4124.246094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4156.033203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(4195.242188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4258.621094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4320.144531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(4351.931641 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(4406.912109 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4470.291016 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(4567.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4631.082031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4658.865234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4720.144531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4759.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-76" transform="translate(4787.136719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4846.316406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4907.839844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(4939.626953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(5003.103516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5064.382812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5127.761719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5189.285156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5217.068359 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(5248.855469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(5303.835938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5365.017578 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5428.396484 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(5491.775391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5530.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5583.083984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5614.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-76" transform="translate(5676.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5735.574219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(5797.097656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(5838.210938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5897.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(5929.177734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(5984.158203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(6045.339844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(6108.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(6147.927734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(6189.041016 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(6216.824219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(6280.300781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(6343.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(6382.888672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(6444.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(6485.183594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(6516.970703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(6569.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(6596.853516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(6660.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(6715.212891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(6776.736328 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(6808.523438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(6870.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(6931.326172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(6986.306641 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(7049.685547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(7081.472656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(7144.949219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(7186.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6a" transform="translate(7247.244141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(7275.027344 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(7336.550781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(7391.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-27" transform="translate(7430.740234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(7458.230469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(7510.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(7542.117188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(7577.322266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(7605.105469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(7646.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(7698.318359 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(7737.527344 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(7769.314453 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(7824.294922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(7885.476562 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(7982.888672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(8080.300781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(8108.083984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(8147.292969 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd2a7c7eff6">
+   <rect x="99.326875" y="127.504706" width="1165.1" height="380.208627"/>
+  </clipPath>
+  <clipPath id="p2da38cfa41">
+   <rect x="99.326875" y="550.698039" width="1165.1" height="380.208627"/>
+  </clipPath>
+  <clipPath id="p221d2e5d59">
+   <rect x="99.326875" y="973.891373" width="1165.1" height="380.208627"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/activity_count.py
+++ b/activity_count.py
@@ -1,0 +1,149 @@
+# This file is part of the uutils coreutils package.
+#
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+
+"""Count monthly commits and contributors for GNU and uutils coreutils.
+
+For each project, walk the git history since `--since` and bucket every
+non-merge commit by its author month (UTC). We record, per month:
+
+  commits — number of non-merge commits
+  authors — distinct authors active that month
+  cumulative_authors — distinct authors seen since the project's first
+                       commit (not just since `--since`)
+
+Authors are deduplicated by mailmapped email (lowercased); bots
+(dependabot, renovate, github-actions, …) are excluded from both counts.
+
+The result is a JSON object keyed by month (`YYYY-MM`), each holding one
+entry per project:
+
+  {"2021-01": {"gnu": {"commits": "42", ...}, "uutils": {...}}, ...}
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timedelta, timezone
+
+BOT_PATTERNS = [
+    re.compile(r"\[bot\]"),
+    re.compile(r"\bdependabot\b"),
+    re.compile(r"\brenovate\b"),
+    re.compile(r"github-actions"),
+    re.compile(r"^actions@github\.com$"),
+]
+
+
+def is_bot(email: str, name: str) -> bool:
+    haystack = f"{email} {name}".lower()
+    return any(p.search(haystack) for p in BOT_PATTERNS)
+
+
+def git(repo: str, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", repo, *args], text=True)
+
+
+def month_range(since: str, until: str) -> list[str]:
+    """All `YYYY-MM` keys from `since` up to `until` (exclusive)."""
+    start = date.fromisoformat(f"{since[:7]}-01")
+    # `until` is exclusive, so the last reported month is the one holding the
+    # day before it.
+    end = date.fromisoformat(until[:10]) - timedelta(days=1)
+    months = []
+    y, m = start.year, start.month
+    while (y, m) <= (end.year, end.month):
+        months.append(f"{y:04d}-{m:02d}")
+        m += 1
+        if m == 13:
+            y, m = y + 1, 1
+    return months
+
+
+def collect(repo: str, since: str, until: str, rev: str) -> dict[str, dict[str, str]]:
+    """Per-month commit/author counts for `repo` in [since, until).
+
+    Only the reported months are limited by `since`: the whole history up to
+    `until` is walked, so `cumulative_authors` counts every contributor the
+    project ever had, not just those since `since`.
+    """
+    log = git(
+        repo,
+        "log",
+        rev,
+        "--no-merges",
+        "--use-mailmap",
+        f"--until={until}",
+        "--date=format-local:%Y-%m",
+        "--pretty=format:%ad\x1f%aE\x1f%aN",
+    )
+
+    per_month: dict[str, dict] = {}
+    for line in log.splitlines():
+        if not line.strip():
+            continue
+        month, email, name = line.split("\x1f")
+        if is_bot(email, name):
+            continue
+        bucket = per_month.setdefault(month, {"commits": 0, "authors": set()})
+        bucket["commits"] += 1
+        bucket["authors"].add(email.lower())
+
+    result = {}
+    seen: set[str] = set()
+    reported = set(month_range(since, until))
+    # Walk every month the repo has, oldest first, so the cumulative author
+    # set carries the pre-`since` history into the first reported month.
+    for month in sorted(per_month.keys() | reported):
+        bucket = per_month.get(month, {"commits": 0, "authors": set()})
+        seen |= bucket["authors"]
+        if month not in reported:
+            continue
+        result[month] = {
+            "commits": str(bucket["commits"]),
+            "authors": str(len(bucket["authors"])),
+            "cumulative_authors": str(len(seen)),
+        }
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gnu", help="path to a coreutils/coreutils git checkout")
+    parser.add_argument("uutils", help="path to a uutils/coreutils git checkout")
+    parser.add_argument(
+        "--since",
+        default="2021-01-01",
+        help="first month to report (default: 2021-01-01)",
+    )
+    parser.add_argument(
+        "--until",
+        default=None,
+        help="exclusive end date (default: the 1st of the current month)",
+    )
+    parser.add_argument("--gnu-rev", default="HEAD", help="GNU revision to walk")
+    parser.add_argument("--uutils-rev", default="HEAD", help="uutils revision to walk")
+    args = parser.parse_args()
+
+    # Default to the start of the current month: the running month is always
+    # partial, and a half-counted month reads as a collapse in activity.
+    if args.until is None:
+        today = datetime.now(timezone.utc).date()
+        args.until = date(today.year, today.month, 1).isoformat()
+
+    gnu = collect(args.gnu, args.since, args.until, args.gnu_rev)
+    uutils = collect(args.uutils, args.since, args.until, args.uutils_rev)
+
+    merged = {
+        month: {"gnu": gnu[month], "uutils": uutils[month]} for month in sorted(gnu)
+    }
+    json.dump(merged, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/graph.py
+++ b/graph.py
@@ -11,13 +11,13 @@ import seaborn as sns
 
 from graph_common import (
     COLORS,
-    setup_theme,
-    apply_smoothing,
-    style_axes,
-    add_title,
-    style_legend,
-    add_reference_lines,
     add_gnu_release_markers,
+    add_reference_lines,
+    add_title,
+    apply_smoothing,
+    setup_theme,
+    style_axes,
+    style_legend,
 )
 
 if len(sys.argv) <= 2:
@@ -128,13 +128,13 @@ textstr += f"Fail: {fail_pct:.1f}%\n"
 textstr += f"Skip: {skip_pct:.1f}%"
 
 # Add text box on the top right
-props = dict(
-    boxstyle="round,pad=0.8",
-    facecolor="#FFFFFF",
-    edgecolor="#D1D5DB",
-    linewidth=2,
-    alpha=0.95,
-)
+props = {
+    "boxstyle": "round,pad=0.8",
+    "facecolor": "#FFFFFF",
+    "edgecolor": "#D1D5DB",
+    "linewidth": 2,
+    "alpha": 0.95,
+}
 ax.text(
     0.98,
     1.15,

--- a/graph_common.py
+++ b/graph_common.py
@@ -8,7 +8,6 @@
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-
 # Modern vibrant color palette
 COLORS = {
     "total": "#0066CC",  # Vibrant blue

--- a/individual-size-graph.py
+++ b/individual-size-graph.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
-from graph_common import COLORS, setup_theme, apply_smoothing, style_axes, add_title
+from graph_common import COLORS, add_title, apply_smoothing, setup_theme, style_axes
 
 df = pd.read_json(sys.argv[1], orient="index")
 df.index = pd.to_datetime(df.index, utc=True)

--- a/size-graph.py
+++ b/size-graph.py
@@ -11,10 +11,10 @@ import seaborn as sns
 
 from graph_common import (
     COLORS,
-    setup_theme,
-    apply_smoothing,
-    style_axes,
     add_title,
+    apply_smoothing,
+    setup_theme,
+    style_axes,
     style_legend,
 )
 

--- a/unsafe-graph.py
+++ b/unsafe-graph.py
@@ -15,8 +15,8 @@ import pandas as pd
 import seaborn as sns
 
 from graph_common import (
-    setup_theme,
     apply_smoothing,
+    setup_theme,
     style_axes,
     style_legend,
 )

--- a/unsafe_count.py
+++ b/unsafe_count.py
@@ -79,7 +79,7 @@ def count_at(repo: str, sha: str) -> dict[str, int]:
             continue
         for line in blob.splitlines():
             stripped = line.lstrip()
-            if stripped.startswith("//") or stripped.startswith("*"):
+            if stripped.startswith(("//", "*")):
                 continue
             for type_name, regex in TYPE_PATTERNS:
                 if regex.search(line):


### PR DESCRIPTION
Add activity_count.py, which walks both git histories and records, per month since 2021: non-merge commits, active contributors and cumulative distinct contributors. Authors are deduplicated via mailmap and bots are excluded. The cumulative count covers each project's full history, not just the reported range.

activity-graph.py renders the three metrics as stacked panels sharing an x-axis, in the same style as the other graphs.

The CI job checks out both histories (blobless, full depth), regenerates the data and commits the refreshed graph, like the other trackers.

Also fix the lint errors the latest ruff reports on the existing files, which were failing the lint job.